### PR TITLE
Verify for null before calling setVolume

### DIFF
--- a/src/connection/voiceHandler.js
+++ b/src/connection/voiceHandler.js
@@ -316,10 +316,10 @@ class VoiceConnection {
     })
     else this.connection.play(resource.stream)
 
-    if (this.cache.volume != 100) {
-      this.connection.audioStream.setVolume(this.cache.volume)
-      this.config.volume = 100
-    }
+    if (this.connection.audioStream && this.cache.volume != 100) {
+      this.connection.audioStream.setVolume(this.cache.volume);
+      this.config.volume = 100;
+    }    
 
     if (this.config.paused) {
       this.cache.pauseTime[1] = Date.now()


### PR DESCRIPTION
## Changes

Prevents `null` TypeError.

## Why 

To ensure a stream is playing/cached before trying to modify its volume.

## Checkmarks

- [X] The modified endpoints have been tested.
- [X] Used the same indentation as the rest of the project.
- [X] Still compatible with LavaLink clients.
