### PR TITLE
Send `resumed` in ready payload instead of `resume`.

### DIFF
--- a/src/connection/handler.js
+++ b/src/connection/handler.js
@@ -93,7 +93,7 @@ function setupConnection(ws, req) {
 
       ws.send(JSON.stringify({
         op: 'ready',
-        resume: true,
+        resumed: true,
         sessionId: req.headers['session-id'],
       }))
     }
@@ -109,7 +109,7 @@ function setupConnection(ws, req) {
 
     ws.send(JSON.stringify({
       op: 'ready',
-      resume: false,
+      resumed: false,
       sessionId,
     }))
   }


### PR DESCRIPTION
## Changes

This changes the `resume` field to `resumed` to be inline with what Lavalink clients should expect, as per the implementation documentation at https://lavalink.dev/api/websocket.html#ready-op

## Why 

During my testing, my client was looking for a `resumed` field but was not seeing it, and throwing an error causing the websocket connection to be immediately terminated with no attempt at reconnecting. I don't believe this is the duty of clients to change as this server markets itself as being generally compatible with clients, thus the core implementation should at least match that.

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information

N/A.