### PR TITLE
Fix and add keys in /v4/info

### DIFF
--- a/src/connection/handler.js
+++ b/src/connection/handler.js
@@ -150,6 +150,9 @@ async function requestHandler(req, res) {
         commitTime: -1
       },
       nodejs: process.version,
+      isNodeLink: true,
+      jvm: '0.0.0',
+      lavaplayer: '0.0.0',
       sourceManagers: Object.keys(config.search.sources).filter((source) => {
         if (typeof config.search.sources[source] == 'boolean') return source
         return source.enabled


### PR DESCRIPTION
## Changes

Add jvm, lavaplayer and isNodeLink keys to /v4/info endpoint.

## Why

To ensure compability with some clients, add jvm and lavaplayer keys in /v4/info.

And for indentification of NodeLink nodes, isNodeLink key.

## Checkmarks
- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
 - [x] Still compatible with LavaLink clients.

## Additional information

None