### PR TITLE
Fix crash on paused

### DIFF
--- a/src/connection/handler.js
+++ b/src/connection/handler.js
@@ -784,7 +784,7 @@ async function requestHandler(req, res) {
 
           if (!player) player = new VoiceConnection(guildId, client)
 
-          player.pause(buffer.paused)
+          if (player.connection.ws) player.pause(buffer.paused)
 
           client.players.set(guildId, player)
 


### PR DESCRIPTION
## Changes

This fixes an issue that happens when a client sends a pause request when nothing is being played.

## Why 

To improve NodeLink stability.

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.
