### PR TITLE
Fix paused crash and missing keys, adds isNodeLink key

### DIFF
--- a/src/connection/handler.js
+++ b/src/connection/handler.js
@@ -784,7 +784,7 @@ async function requestHandler(req, res) {
 
           if (!player) player = new VoiceConnection(guildId, client)
 
-          player.pause(buffer.paused)
+          if (player.connection.ws) player.pause(buffer.paused)
 
           client.players.set(guildId, player)
 

--- a/src/connection/handler.js
+++ b/src/connection/handler.js
@@ -709,19 +709,19 @@ async function requestHandler(req, res) {
           debugLog('voice', 1, { params: parsedUrl.search, headers: req.headers, body: buffer })
         }
 
-        if (buffer.encodedTrack !== undefined || buffer.encodedTrack === null) {
+        if (buffer.track?.encoded !== undefined || buffer.track?.encoded === null) {
           const noReplace = parsedUrl.searchParams.get('noReplace')
 
           if (!player) player = new VoiceConnection(guildId, client)
 
-          if (buffer.encodedTrack == null) player.config.track ? player.stop() : null
+          if (buffer.track.encoded == null) player.config.track ? player.stop() : null
           else {
             if (!player.connection) player.setup()
 
-            const decodedTrack = decodeTrack(buffer.encodedTrack)
+            const decodedTrack = decodeTrack(buffer.track.encoded)
 
             if (!decodedTrack) {
-              debugLog('play', 3, { track: buffer.encodedTrack, exception: { message: 'The provided track is invalid.', severity: 'common', cause: 'Invalid track' } })
+              debugLog('play', 3, { track: buffer.track.encoded, exception: { message: 'The provided track is invalid.', severity: 'common', cause: 'Invalid track' } })
         
               return sendResponse(req, res, {
                 timestamp: new Date(),
@@ -733,18 +733,29 @@ async function requestHandler(req, res) {
             }
 
             if (!player.config.voice.endpoint) {
-              player.cache.track = buffer.encodedTrack
+              player.cache.track = buffer.track.encoded
             } else {
               if (player.connection.state.status != 'connecting' || player.connection.state.status != 'ready') player.updateVoice(player.config.voice)
   
-              player.play(buffer.encodeTrack, decodedTrack, noReplace == true)
+              player.play(buffer.track.encoded, decodedTrack, noReplace == true)
             }
           }
 
           client.players.set(guildId, player)
 
-          if (buffer.encodedTrack == null) debugLog('stop', 1, { params: parsedUrl.search, headers: req.headers, body: buffer })
+          if (buffer.track.encoded == null) debugLog('stop', 1, { params: parsedUrl.search, headers: req.headers, body: buffer })
           else debugLog('play', 1, { params: parsedUrl.search, headers: req.headers, body: buffer })
+        }
+
+        if (buffer.track?.userData !== undefined) {
+          if (!player) player = new VoiceConnection(guildId, client)
+
+          player.config.track = {
+            ...(player.config.track ? player.config.track : {}),
+            userData: buffer.userData
+          }
+
+          debugLog('userData', 1, { params: parsedUrl.search, params: parsedUrl.search, body: buffer })
         }
 
         if (buffer.volume != undefined) {

--- a/src/connection/voiceHandler.js
+++ b/src/connection/voiceHandler.js
@@ -240,7 +240,8 @@ class VoiceConnection {
         guildId: this.config.guildId,
         track: {
           encoded: track,
-          info: decodedTrack
+          info: decodedTrack,
+          userData: this.config.track.userData
         },
         reason: 'loadFailed'
       }))
@@ -290,7 +291,8 @@ class VoiceConnection {
         guildId: this.config.guildId,
         track: {
           encoded: track,
-          info: decodedTrack
+          info: decodedTrack,
+          userData: this.config.track.userData
         },
         exception: resource.exception
       }))
@@ -301,7 +303,8 @@ class VoiceConnection {
         guildId: this.config.guildId,
         track: {
           encoded: track,
-          info: decodedTrack
+          info: decodedTrack,
+          userData: this.config.track.userData
         },
         reason: 'loadFailed'
       }))


### PR DESCRIPTION
## Changes

This PR fixes:

- Crash once paused was requested without a playing player.
- Missing keys in /v4/info.

And adds:

- isNodeLink key in /v4/info.
- userData system.

## Why 

To ensure the compability with some clients, like Coglink, and to improve NodeLink's compability, following latest changes of LavaLink.

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.
