### PR TITLE
Add native transcoding

### DIFF
--- a/src/connection/handler.js
+++ b/src/connection/handler.js
@@ -93,7 +93,7 @@ function setupConnection(ws, req) {
 
       ws.send(JSON.stringify({
         op: 'ready',
-        resume: true,
+        resumed: true,
         sessionId: req.headers['session-id'],
       }))
     }
@@ -109,7 +109,7 @@ function setupConnection(ws, req) {
 
     ws.send(JSON.stringify({
       op: 'ready',
-      resume: false,
+      resumed: false,
       sessionId,
     }))
   }

--- a/src/connection/handler.js
+++ b/src/connection/handler.js
@@ -150,6 +150,9 @@ async function requestHandler(req, res) {
         commitTime: -1
       },
       nodejs: process.version,
+      isNodeLink: true,
+      jvm: '0.0.0',
+      lavaplayer: '0.0.0',
       sourceManagers: Object.keys(config.search.sources).filter((source) => {
         if (typeof config.search.sources[source] == 'boolean') return source
         return source.enabled

--- a/src/connection/handler.js
+++ b/src/connection/handler.js
@@ -787,7 +787,7 @@ async function requestHandler(req, res) {
 
           if (!player) player = new VoiceConnection(guildId, client)
 
-          player.pause(buffer.paused)
+          if (player.connection.ws) player.pause(buffer.paused)
 
           client.players.set(guildId, player)
 

--- a/src/connection/handler.js
+++ b/src/connection/handler.js
@@ -712,19 +712,19 @@ async function requestHandler(req, res) {
           debugLog('voice', 1, { params: parsedUrl.search, headers: req.headers, body: buffer })
         }
 
-        if (buffer.encodedTrack !== undefined || buffer.encodedTrack === null) {
+        if (buffer.track?.encoded !== undefined || buffer.track?.encoded === null) {
           const noReplace = parsedUrl.searchParams.get('noReplace')
 
           if (!player) player = new VoiceConnection(guildId, client)
 
-          if (buffer.encodedTrack == null) player.config.track ? player.stop() : null
+          if (buffer.track.encoded == null) player.config.track ? player.stop() : null
           else {
             if (!player.connection) player.setup()
 
-            const decodedTrack = decodeTrack(buffer.encodedTrack)
+            const decodedTrack = decodeTrack(buffer.track.encoded)
 
             if (!decodedTrack) {
-              debugLog('play', 3, { track: buffer.encodedTrack, exception: { message: 'The provided track is invalid.', severity: 'common', cause: 'Invalid track' } })
+              debugLog('play', 3, { track: buffer.track.encoded, exception: { message: 'The provided track is invalid.', severity: 'common', cause: 'Invalid track' } })
         
               return sendResponse(req, res, {
                 timestamp: new Date(),
@@ -736,18 +736,29 @@ async function requestHandler(req, res) {
             }
 
             if (!player.config.voice.endpoint) {
-              player.cache.track = buffer.encodedTrack
+              player.cache.track = buffer.track.encoded
             } else {
               if (player.connection.state.status != 'connecting' || player.connection.state.status != 'ready') player.updateVoice(player.config.voice)
   
-              player.play(buffer.encodeTrack, decodedTrack, noReplace == true)
+              player.play(buffer.track.encoded, decodedTrack, noReplace == true)
             }
           }
 
           client.players.set(guildId, player)
 
-          if (buffer.encodedTrack == null) debugLog('stop', 1, { params: parsedUrl.search, headers: req.headers, body: buffer })
+          if (buffer.track.encoded == null) debugLog('stop', 1, { params: parsedUrl.search, headers: req.headers, body: buffer })
           else debugLog('play', 1, { params: parsedUrl.search, headers: req.headers, body: buffer })
+        }
+
+        if (buffer.track?.userData !== undefined) {
+          if (!player) player = new VoiceConnection(guildId, client)
+
+          player.config.track = {
+            ...(player.config.track ? player.config.track : {}),
+            userData: buffer.userData
+          }
+
+          debugLog('userData', 1, { params: parsedUrl.search, params: parsedUrl.search, body: buffer })
         }
 
         if (buffer.volume != undefined) {

--- a/src/connection/voiceHandler.js
+++ b/src/connection/voiceHandler.js
@@ -240,7 +240,8 @@ class VoiceConnection {
         guildId: this.config.guildId,
         track: {
           encoded: track,
-          info: decodedTrack
+          info: decodedTrack,
+          userData: this.config.track.userData
         },
         reason: 'loadFailed'
       }))
@@ -290,7 +291,8 @@ class VoiceConnection {
         guildId: this.config.guildId,
         track: {
           encoded: track,
-          info: decodedTrack
+          info: decodedTrack,
+          userData: this.config.track.userData
         },
         exception: resource.exception
       }))
@@ -301,7 +303,8 @@ class VoiceConnection {
         guildId: this.config.guildId,
         track: {
           encoded: track,
-          info: decodedTrack
+          info: decodedTrack,
+          userData: this.config.track.userData
         },
         reason: 'loadFailed'
       }))

--- a/src/connection/voiceHandler.js
+++ b/src/connection/voiceHandler.js
@@ -208,7 +208,7 @@ class VoiceConnection {
 
       this.cache.url = urlInfo.url
 
-      resolve({ stream: voiceUtils.createAudioResource(streamInfo.stream) })
+      resolve({ stream: voiceUtils.createAudioResource(streamInfo.stream, urlInfo.format) })
     })
   }
 

--- a/src/sources.js
+++ b/src/sources.js
@@ -22,14 +22,14 @@ async function getTrackURL(track) {
         break
       }
       case 'local': {
-        resolve({ url: track.uri, protocol: 'file' })
+        resolve({ url: track.uri, protocol: 'file', format: 'arbitrary' })
 
         break
       }
 
       case 'http':
       case 'https': {
-        resolve({ url: track.uri, protocol: track.sourceName })
+        resolve({ url: track.uri, protocol: track.sourceName, format: 'arbitrary' })
         
         break
       }

--- a/src/voice/utils.js
+++ b/src/voice/utils.js
@@ -82,7 +82,20 @@ class NodeLinkStream {
   }
 }
 
-function createAudioResource(stream) {
+function createAudioResource(stream, type) {
+  if ([ 'webm/opus', 'ogg/opus' ].includes(type)) {
+    return new NodeLinkStream(stream, [
+      new prism.opus[type == 'webm/opus' ? 'WebmDemuxer' : 'OggDemuxer'](),
+      new prism.opus.Decoder({ frameSize: 960, channels: 2, rate: 48000 }),
+      new prism.VolumeTransformer({ type: 's16le' }),
+      new prism.opus.Encoder({
+        rate: constants.opus.samplingRate,
+        channels: constants.opus.channels,
+        frameSize: constants.opus.frameSize
+      })
+    ])
+  }
+
   const ffmpeg = new prism.FFmpeg({
     args: [
       '-loglevel', '0',


### PR DESCRIPTION
## Changes

This PR adds native transcoding from webm/opus and ogg/opus to PCM 16le.

## Why 

This eliminates the overhead created by FFmpeg and child_process, and also allows faster filtering when also uses one of the 3 native filters, which eliminates the need of restarting the stream, just by changing the pipes.

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information

Merging this, this will close #17.
