### PR TITLE
fix: SC not returning tracks

### DIFF
--- a/src/sources/soundcloud.js
+++ b/src/sources/soundcloud.js
@@ -246,10 +246,12 @@ async function search(query, shouldLog) {
     body.collection = body.collection.filter((item, i) => i < config.options.maxSearchResults || item.kind === 'track')
 
   body.collection.forEach((item) => {
+    if (item.kind !== 'track') return;
+    
     const track = {
       identifier: item.id.toString(),
       isSeekable: true,
-      author: item.user?.username || 'Unknown',
+      author: item.user.username,
       length: item.duration,
       isStream: false,
       position: 0,


### PR DESCRIPTION
## Changes

Write here about the changes you've made

Added an extra condition so that only SoundCloud tracks will be returned on request.

## Why 

Write here why you think this should be merged

It fixes an improntant issue related to SoundCloud information retrieval.

## Checkmarks

- [ X ] The modified endpoints have been tested.
- [ X ] Used the same indentation as the rest of the project.
- [ X ] Still compatible with LavaLink clients.

## Additional information

If you have any additional information, write it here
