### PR TITLE
Syntax fix on voiceHandler.js

### DIFF
--- a/src/connection/voiceHandler.js
+++ b/src/connection/voiceHandler.js
@@ -104,7 +104,7 @@ class VoiceConnection {
     })
 
     this.connection.on('error', (error) => {
-      if (this.config.track) nodeLinkPlayingPlayersCount--
+      if (this.config.track) nodelinkPlayingPlayersCount--
 
       debugLog('trackException', 2, { track: this.config.track?.info, exception: error.message })
 
@@ -176,7 +176,7 @@ class VoiceConnection {
 
     this._stopTrack()
 
-    nodeLinkPlayersCount--
+    nodelinkPlayersCount--
   }
 
   async getResource(decodedTrack, urlInfo) {


### PR DESCRIPTION
## Changes

I made a small modification on the following variables
nodelinkPlayersCount , nodelinkPlayingPlayersCount

## Why 

When a client player disconnects, it will cause NL to crash due to syntax error.

## Checkmarks

- [Yes] The modified endpoints have been tested.
- [Yes] Used the same indentation as the rest of the project.
- [Yes] Still compatible with LavaLink clients.