### PR TITLE
CI(docker-image): Bump `docker/metadata-action` to v5

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Generate Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/nodelink
           tags: |


### PR DESCRIPTION
This commit updates `docker/metadata-action` to v5, that updates nodejs to v20 internally.

## Changes
- Updated `docker/metadata-action` to v5

## Why 

It's required to update it to nodejs v20 and v5 updates those, as GitHub as removed support from node v16 more info at https://github.com/PerformanC/voice/pull/2

## Checkmarks

- [x] checked to ensure it updates nodejs version on respective version v5.

## Additional information

For proper info check here:
1. https://github.com/PerformanC/voice/pull/2
2. https://github.com/docker/metadata-action/releases/tag/v5.0.0
3. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/