### PR TITLE
fix: YT search accessing `content` property instead of `contents`

### DIFF
--- a/src/sources/youtube.js
+++ b/src/sources/youtube.js
@@ -183,7 +183,7 @@ async function search(query, type, shouldLog) {
 
   let videos = null
   if (config.search.sources.youtube.bypassAgeRestriction) videos = type == 'ytmusic' ? search.contents?.sectionListRenderer?.contents[0]?.itemSectionRenderer?.contents : search.contents?.sectionListRenderer?.contents[search.contents?.sectionListRenderer?.contents.length - 1]?.itemSectionRenderer?.contents
-  else videos = type == 'ytmusic' ? search.contents.tabbedSearchResultsRenderer.tabs[0].tabRenderer.content.musicSplitViewRenderer?.mainContent?.sectionListRenderer?.contents[0]?.musicShelfRenderer?.contents : search.contents.sectionListRenderer.contents[search.contents.sectionListRenderer.contents.length - 1].itemSectionRenderer.content
+  else videos = type == 'ytmusic' ? search.contents.tabbedSearchResultsRenderer.tabs[0].tabRenderer.content.musicSplitViewRenderer?.mainContent?.sectionListRenderer?.contents[0]?.musicShelfRenderer?.contents : search.contents.sectionListRenderer.contents[search.contents.sectionListRenderer.contents.length - 1].itemSectionRenderer.contents
 
   if (!videos) {
     debugLog('search', 4, { type: 3, sourceName: _getSourceName(type), query, message: 'No matches found.' })


### PR DESCRIPTION
## Changes

- [x] fixes the `contents` property written as `content` Caused by https://github.com/PerformanC/NodeLink/commit/441a319f96bbd09dc55a8f02d90ab4b13f07276f

## Why 

This Change Fixes the **No Tracks Found** or `loadType: empty` Issue For Yt search.

That was caused By https://github.com/PerformanC/NodeLink/commit/441a319f96bbd09dc55a8f02d90ab4b13f07276f

## Checkmarks

- [x] Used the same indentation as the rest of the project.
- [x] Changed Code has been tested, accepted that it works.

## Additional information

NONE
