### PR TITLE
fix: :ambulance: TrackStart event not emitting while track skipped/replaced

### DIFF
--- a/src/connection/voiceHandler.js
+++ b/src/connection/voiceHandler.js
@@ -217,6 +217,15 @@ class VoiceConnection {
         track: this.config.track,
         reason: 'replaced'
       }))
+
+      debugLog('trackStart', 2, { track: this.config.track.info })
+
+      this.client.ws.send(JSON.stringify({
+        op: 'event',
+        type: 'TrackStartEvent',
+        guildId: this.config.guildId,
+        track: this.config.track
+      }))
     }
 
     let resource = null


### PR DESCRIPTION


## Changes
This commit fixes the trackStart event not being sent by NodeLink while track is replaced/Skipped

## Why 

Resolves the `trackStart` not being emitted if the track was skipped/replaced

## Checkmarks

- [X] The modified endpoints have been tested.
- [X] Used the same indentation as the rest of the project.
- [X] Still compatible with LavaLink clients.