### PR TITLE
change: add missing word

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ npm i
 ```
 
 > [!NOTE]
-> If you to use pure JavaScript, replace `sodium-native` with `libsodium-wrappers`. Keep in mind that pure JavaScript will offer a worse performance.
+> If you want to use pure JavaScript, replace `sodium-native` with `libsodium-wrappers`. Keep in mind that pure JavaScript will offer a worse performance.
 
 ### 3. Run NodeLink
 


### PR DESCRIPTION
## Changes

added a missing word on the readme file

## Why 

Because the sentence is not complete as it is.

## Checkmarks

- [X] The modified endpoints have been tested.
- [X] Used the same indentation as the rest of the project.
- [X] Still compatible with LavaLink clients.

## Additional information

Nothing else
