### PR TITLE
Add poru to the supported clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ NodeLink is compatible with most LavaLink clients, as it implements most of the 
 | [Shoukaku](https://github.com/Deivu/Shoukaku)                       | Typescript   | Yes             | No                  | v1 and v2              |
 | [Lavalink-Client](https://github.com/tomato6966/Lavalink-Client)    | Typescript   | No              | No                  | v1                     |
 | [Rainlink](https://github.com/RainyXeon/Rainlink)                   | Typescript   | Yes             | Yes                 | v1 and v2              |
+| [Poru](https://github.com/parasop/Poru)                             | Typescript   | Yes             | Yes                 | v1 and v2              |
 | [Blue.ts](https://github.com/ftrapture/blue.ts)                     | Typescript   | No              | No                  | v1 and v2              | 
 | [FastLink](https://github.com/PerformanC/FastLink)                  | Node.js      | Yes             | Yes                 | v1 and v2              |
 | [Riffy](https://github.com/riffy-team/riffy)                        | Node.js      | Yes             | No                  | v1 and v2              |


### PR DESCRIPTION
## Changes

I have added Poru to the supported clients list

## Why 

Because Poru now supports all of NodeLink's features and is still missing on this list.

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information

None.
