### PR TITLE
fix: Player's position returning 0 when paused

### DIFF
--- a/src/connection/handler.js
+++ b/src/connection/handler.js
@@ -460,8 +460,8 @@ async function requestHandler(req, res) {
     client.players.forEach((player) => {
       player.config.state = {
         time: Date.now(),
-        position: player.connection ? player.connection.playerState.status === 'playing' ? player._getRealTime() : 0 : 0,
-        connected: player.connection ? player.connection.state.status === 'ready' : false,
+        position: player.connection ? (player.connection.playerState.status === 'playing' || player.connection.playerState.reason === 'paused') ? player._getRealTime() : 0 : 0,
+        connected: player.connection ? player.connection.state.status === 'connected' : false,
         ping: player.connection?.ping || -1
       }
 
@@ -547,8 +547,8 @@ async function requestHandler(req, res) {
 
       player.config.state = {
         time: Date.now(),
-        position: player.connection ? player.connection.playerState.status === 'playing' ? player._getRealTime() : 0 : 0,
-        connected: player.connection ? player.connection.state.status === 'ready' : false,
+        position: player.connection ? (player.connection.playerState.status === 'playing' || player.connection.playerState.reason === 'paused') ? player._getRealTime() : 0 : 0,
+        connected: player.connection ? player.connection.state.status === 'connected' : false,
         ping: player.connection?.ping || -1
       }
 
@@ -778,8 +778,8 @@ async function requestHandler(req, res) {
       /* Updating player state to ensure it's sending up-to-date data */
       player.config.state = {
         time: Date.now(),
-        position: player.connection ? player.connection.playerState.status === 'playing' ? player._getRealTime() : 0 : 0,
-        connected: player.connection ? player.connection.state.status === 'ready' : false,
+        position: player.connection ? (player.connection.playerState.status === 'playing' || player.connection.playerState.reason === 'paused') ? player._getRealTime() : 0 : 0,
+        connected: player.connection ? player.connection.state.status === 'connected' : false,
         ping: player.connection?.ping || -1 
       }
 


### PR DESCRIPTION
## Changes

- fixed the player's position falling back to **0** when paused
- Corrects the Player's connected property that's being `false` always as it check for an outdated connection status (`ready` instead of `connected`)

## Why 

The PR fixes the player's position falling back to **0** when paused. Also Corrects the Player's connected property that's being `false` always as it check for an outdated connection status (`ready` instead of `connected`)

## Checkmarks

- [X] The modified endpoints have been tested.
- [X] Used the same indentation as the rest of the project.
- [X] Still compatible with LavaLink clients.

## Additional information

Fixes: https://github.com/PerformanC/NodeLink/issues/74