### PR TITLE
fix: replace undefined variable url with query

### DIFF
--- a/src/sources/spotify.js
+++ b/src/sources/spotify.js
@@ -152,7 +152,7 @@ async function search(query) {
 
 async function loadFrom(query, type) {
   if (!globalThis.NodeLinkSources.Spotify) {
-    debugLog('loadtracks', 4, { type: 3, sourceName: 'Spotify', query: url, message: 'Spotify source is not available.' })
+    debugLog('loadtracks', 4, { type: 3, sourceName: 'Spotify', query, message: 'Spotify source is not available.' })
 
     return {
       loadType: 'error',


### PR DESCRIPTION
## Changes

Replaces the undefined variable url with query.

## Why 

This prevents unwanted errors showing in console.

## Checkmarks

- [X] The modified endpoints have been tested.
- [X] Used the same indentation as the rest of the project.
- [X] Still compatible with LavaLink clients.

## Additional information

