### PR TITLE
Added feature to suppress too frequent detection of startSpeaking event

### DIFF
--- a/config.js
+++ b/config.js
@@ -174,6 +174,7 @@ export default {
   },
   voiceReceive: {
     type: 'pcm', // pcm, opus
-    timeout: 1000 // 1s of silence to consider as it stopped speaking.
+    timeout: 1000, // 1s of silence to consider as it stopped speaking.
+    gap: 1000 //1s of silence to consider as a new sentence
   }
 }

--- a/src/connection/inputHandler.js
+++ b/src/connection/inputHandler.js
@@ -6,6 +6,7 @@ import discordVoice from '@performanc/voice'
 import prism from 'prism-media'
 
 const Connections = {}
+const speaks = {}
 
 function setupConnection(ws, req, parsedClientName) {
   const userId = req.headers['user-id']
@@ -30,6 +31,12 @@ function setupConnection(ws, req, parsedClientName) {
 }
 
 function handleStartSpeaking(ssrc, userId, guildId) {
+  if(speaks[userId) return;
+  if(!speaks[userId]) speaks[userId] = true;
+  setTimeout(() => {
+		speaks[userId] = false;
+	}, config.voiceReceive.gap);
+
   const opusStream = discordVoice.getSpeakStream(ssrc)
   const stream = new voiceUtils.NodeLinkStream(opusStream, config.voiceReceive.type === 'pcm' ? [ new prism.opus.Decoder({ rate: 48000, channels: 2, frameSize: 960 }) ] : [])
   let timeout = null
@@ -91,6 +98,8 @@ function handleStartSpeaking(ssrc, userId, guildId) {
         if (Connections[botId].guildId !== guildId) return;
 
         Connections[botId].ws.send(endSpeakingResponse)
+
+        delete speaks[userId];
 
         i++
       })

--- a/src/connection/inputHandler.js
+++ b/src/connection/inputHandler.js
@@ -32,11 +32,11 @@ function setupConnection(ws, req, parsedClientName) {
 
 function handleStartSpeaking(ssrc, userId, guildId) {
 	if(config.voiceReceive.gap) {
-  	if(speaks[userId) return;
-  	if(!speaks[userId]) speaks[userId] = true;
-  	setTimeout(() => {
-			speaks[userId] = false;
-		}, config.voiceReceive.gap);
+  		if(speaks[userId) return
+  		if(!speaks[userId]) speaks[userId] = true
+  		setTimeout(() => {
+				speaks[userId] = false
+			}, config.voiceReceive.gap)
 	}
 
   const opusStream = discordVoice.getSpeakStream(ssrc)

--- a/src/connection/inputHandler.js
+++ b/src/connection/inputHandler.js
@@ -31,11 +31,13 @@ function setupConnection(ws, req, parsedClientName) {
 }
 
 function handleStartSpeaking(ssrc, userId, guildId) {
-  if(speaks[userId) return;
-  if(!speaks[userId]) speaks[userId] = true;
-  setTimeout(() => {
-		speaks[userId] = false;
-	}, config.voiceReceive.gap);
+	if(config.voiceReceive.gap) {
+  	if(speaks[userId) return;
+  	if(!speaks[userId]) speaks[userId] = true;
+  	setTimeout(() => {
+			speaks[userId] = false;
+		}, config.voiceReceive.gap);
+	}
 
   const opusStream = discordVoice.getSpeakStream(ssrc)
   const stream = new voiceUtils.NodeLinkStream(opusStream, config.voiceReceive.type === 'pcm' ? [ new prism.opus.Decoder({ rate: 48000, channels: 2, frameSize: 960 }) ] : [])
@@ -99,7 +101,8 @@ function handleStartSpeaking(ssrc, userId, guildId) {
 
         Connections[botId].ws.send(endSpeakingResponse)
 
-        delete speaks[userId];
+				
+        if(config.voiceReceive.gap) delete speaks[userId]
 
         i++
       })

--- a/src/connection/inputHandler.js
+++ b/src/connection/inputHandler.js
@@ -32,7 +32,7 @@ function setupConnection(ws, req, parsedClientName) {
 
 function handleStartSpeaking(ssrc, userId, guildId) {
 	if(config.voiceReceive.gap) {
-  		if(speaks[userId) return
+  		if(speaks[userId]) return
   		if(!speaks[userId]) speaks[userId] = true
   		setTimeout(() => {
 				speaks[userId] = false


### PR DESCRIPTION
## Changes

Added feature to suppress too frequent detection of startSpeaking event.

## Why 

Good. Very easy to use, and it can even be disabled.


## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information

Nothing to see here.