### PR TITLE
fix(spotify): add TOTP parameters for authentication

### DIFF
--- a/src/sources/youtube.js
+++ b/src/sources/youtube.js
@@ -176,8 +176,9 @@ async function _fetchVisitorData() {
     
     try {
       let parsed = data.replace(/^\)]}'\n/, '')
-      parsed = JSON.parse(cleanedData)
+      parsed = JSON.parse(parsed)
       ytContext.client.visitorData = parsed[0][2][6]
+      debugLog('youtube', 5, { type: 1, message: 'Successfully fetched visitor data: ' + ytContext.client.visitorData })
     } catch (e) { 
       debugLog('youtube', 5, { type: 2, message: `Failed to fetch visitor data: ${e.message}` })
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -170,16 +170,21 @@ function _http2Events(request, headers) {
     let data = ''
 
     request.setEncoding('utf8')
-    request.on('data', (chunk) => data += chunk)
+    request.on('data', chunk => data += chunk)
     request.on('end', () => {
-      resolve({
-        statusCode: headers[':status'],
-        headers: headers,
-        body: (headers && headers['content-type'] && headers['content-type'].startsWith('application/json')) ? JSON.parse(data) : data
-      })
+      let body = data.trim()
+      
+      if (headers?.['content-type']?.startsWith('application/json')) {
+        try { 
+          body = JSON.parse(body) 
+        } catch (_) {}
+      }
+
+      resolve({ statusCode: headers[':status'], headers, body })
     })
   })
 }
+
 
 export function makeRequest(url, options) {
   if (process.versions.deno || process.isBun) return http1makeRequest(url, options)


### PR DESCRIPTION
## Changes

- Added TOTP generation directly to the Spotify token request URL, ensuring that the necessary parameters (reason, productType, totp, totpVer, ts) are sent.

## Why

Previously, the fetch to obtain the Spotify token failed because essential information was missing from the request, specifically the TOTP parameters that are required by the endpoint. With this addition, authentication is performed correctly and the fetch works again, restoring integration with Spotify.

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information

This change corrects the failure to obtain the Spotify token, ensuring that all mandatory data is present in the request. This change is crucial for continuity of operation and compatibility with recent changes to the Spotify endpoint.

Translated with DeepL.com (free version)