### PR TITLE
fix: youtube music urls and androidvr user-agent.

### DIFF
--- a/src/sources/youtube/YouTube.js
+++ b/src/sources/youtube/YouTube.js
@@ -414,9 +414,19 @@ export default class YouTubeSource {
   }
 
   async resolve(url, type) {
+    const isMusicUrl = url.includes('music.youtube.com')
+    const sourceType = isMusicUrl ? 'ytmusic' : 'youtube'
+
+    // Convert music.youtube.com URLs to www.youtube.com format
+    let processUrl = url
+    if (isMusicUrl) {
+      processUrl = url.replace('music.youtube.com', 'www.youtube.com')
+      logger('debug', 'YouTube', `Converted YouTube Music URL to standard format: ${processUrl}`)
+    }
+
     const clientList = this.config.clients.playback
     const clientErrors = []
-    const urlType = checkURLType(url, 'youtube')
+    const urlType = checkURLType(processUrl, sourceType)
 
     // Prioritize Android client for playlists
     if (urlType === YOUTUBE_CONSTANTS.PLAYLIST) {
@@ -429,7 +439,7 @@ export default class YouTubeSource {
             'Attempting to resolve playlist URL with Android client (priority).'
           )
           const result = await androidClient.resolve(
-            url,
+            processUrl,
             type,
             this.ytContext,
             this.cipherManager
@@ -490,7 +500,7 @@ export default class YouTubeSource {
           `Attempting to resolve URL with client: ${clientName}`
         )
         const result = await client.resolve(
-          url,
+          processUrl,
           type,
           this.ytContext,
           this.cipherManager

--- a/src/sources/youtube/clients/AndroidVR.js
+++ b/src/sources/youtube/clients/AndroidVR.js
@@ -227,7 +227,7 @@ export default class AndroidVR extends BaseClient {
         const { body: playlistResponse, statusCode } = await makeRequest(
           `${apiEndpoint}/youtubei/v1/next`,
           {
-            headers: { 'User-Agent': this.getClient(context).userAgent },
+            headers: { 'User-Agent': this.getClient(context).client.userAgent },
             body: {
               context: this.getClient(context),
               playlistId,


### PR DESCRIPTION
## Changes

- Fixed the youtube music loading by adding an check to see if the url contains music.youtube.com, and auto converts it to a www.youtube.com url for playback (works with singular tracks or playlists)
- Fixed AndroidVR client returning undefined on user-agent when loading a playlist (was missing a .client)
## Why 

For youtube music: Properly loading for the youtube music URLs to make it compatible
For androidVR: now its possible to use it again for playlists loading, improving the playback support

## Checkmarks

- [ X ] The modified endpoints have been tested.
- [ X ] Used the same indentation as the rest of the project.
- [ X ] Still compatible with LavaLink clients.

## Additional information
