### PR TITLE
fix: youtube radio lists not beign correctly fetched

### DIFF
--- a/src/sources/youtube/clients/Android.js
+++ b/src/sources/youtube/clients/Android.js
@@ -224,21 +224,26 @@ export default class Android extends BaseClient {
         const videoIdMatch = url.match(/[?&]v=([\w-]+)/)
         const currentVideoId = videoIdMatch?.[1] ?? null
 
+
         logger(
           'debug',
           'YouTube-Android',
           `User-Agent for playlist request: ${this.getClient(context).client.userAgent}`
         )
+        const requestBody = {
+          context: this.getClient(context),
+          playlistId,
+          contentCheckOk: true,
+          racyCheckOk: true
+        }
+        if (playlistId.startsWith('RD') && currentVideoId) {
+          requestBody.videoId = currentVideoId
+        }
         const { body: playlistResponse, statusCode } = await makeRequest(
           `${apiEndpoint}/youtubei/v1/next`,
           {
             headers: { 'User-Agent': this.getClient(context).client.userAgent },
-            body: {
-              context: this.getClient(context),
-              playlistId,
-              contentCheckOk: true,
-              racyCheckOk: true
-            },
+            body: requestBody,
             method: 'POST',
             disableBodyCompression: true
           }

--- a/src/sources/youtube/clients/AndroidVR.js
+++ b/src/sources/youtube/clients/AndroidVR.js
@@ -224,16 +224,20 @@ export default class AndroidVR extends BaseClient {
 
         const currentVideoId = videoIdMatch?.[1] ?? null
 
+        const requestBody = {
+          context: this.getClient(context),
+          playlistId,
+          contentCheckOk: true,
+          racyCheckOk: true
+        }
+        if (playlistId.startsWith('RD') && currentVideoId) {
+          requestBody.videoId = currentVideoId
+        }
         const { body: playlistResponse, statusCode } = await makeRequest(
           `${apiEndpoint}/youtubei/v1/next`,
           {
             headers: { 'User-Agent': this.getClient(context).client.userAgent },
-            body: {
-              context: this.getClient(context),
-              playlistId,
-              contentCheckOk: true,
-              racyCheckOk: true
-            },
+            body: requestBody,
             method: 'POST',
             disableBodyCompression: true
           }

--- a/src/sources/youtube/clients/IOS.js
+++ b/src/sources/youtube/clients/IOS.js
@@ -112,16 +112,20 @@ export default class IOS extends BaseClient {
         const videoIdMatch = url.match(/[?&]v=([\w-]+)/)
         const currentVideoId = videoIdMatch?.[1] ?? null
 
+        const requestBody = {
+          context: this.getClient(context),
+          playlistId,
+          contentCheckOk: true,
+          racyCheckOk: true
+        }
+        if (playlistId.startsWith('RD') && currentVideoId) {
+          requestBody.videoId = currentVideoId
+        }
         const { body: playlistResponse, statusCode } = await makeRequest(
           `${apiEndpoint}/youtubei/v1/next`,
           {
             headers: { 'User-Agent': this.getClient(context).client.userAgent },
-            body: {
-              context: this.getClient(context),
-              playlistId,
-              contentCheckOk: true,
-              racyCheckOk: true
-            },
+            body: requestBody,
             method: 'POST',
             disableBodyCompression: true
           }

--- a/src/sources/youtube/clients/TV.js
+++ b/src/sources/youtube/clients/TV.js
@@ -125,16 +125,20 @@ export default class TV extends BaseClient {
         const videoIdMatch = url.match(/[?&]v=([\w-]+)/)
         const currentVideoId = videoIdMatch?.[1] ?? null
 
+        const requestBody = {
+          context: this.getClient(context),
+          playlistId,
+          contentCheckOk: true,
+          racyCheckOk: true
+        }
+        if (playlistId.startsWith('RD') && currentVideoId) {
+          requestBody.videoId = currentVideoId
+        }
         const { body: playlistResponse, statusCode } = await makeRequest(
           `${apiEndpoint}/youtubei/v1/next`,
           {
             headers: { 'User-Agent': this.getClient(context).client.userAgent },
-            body: {
-              context: this.getClient(context),
-              playlistId,
-              contentCheckOk: true,
-              racyCheckOk: true
-            },
+            body: requestBody,
             method: 'POST',
             disableBodyCompression: true
           }

--- a/src/sources/youtube/clients/TVEmbedded.js
+++ b/src/sources/youtube/clients/TVEmbedded.js
@@ -134,16 +134,20 @@ export default class TVEmbedded extends BaseClient {
         const videoIdMatch = url.match(/[?&]v=([\w-]+)/)
         const currentVideoId = videoIdMatch?.[1] ?? null
 
+        const requestBody = {
+          context: this.getClient(context),
+          playlistId,
+          contentCheckOk: true,
+          racyCheckOk: true
+        }
+        if (playlistId.startsWith('RD') && currentVideoId) {
+          requestBody.videoId = currentVideoId
+        }
         const { body: playlistResponse, statusCode } = await makeRequest(
           `${apiEndpoint}/youtubei/v1/next`,
           {
             headers: { 'User-Agent': this.getClient(context).client.userAgent },
-            body: {
-              context: this.getClient(context),
-              playlistId,
-              contentCheckOk: true,
-              racyCheckOk: true
-            },
+            body: requestBody,
             method: 'POST',
             disableBodyCompression: true
           }

--- a/src/sources/youtube/clients/Web.js
+++ b/src/sources/youtube/clients/Web.js
@@ -195,6 +195,15 @@ export default class Web extends BaseClient {
         const videoIdMatch = url.match(/[?&]v=([\w-]+)/)
         const currentVideoId = videoIdMatch?.[1] ?? null
 
+        const requestBody = {
+          context: this.getClient(context),
+          playlistId,
+          contentCheckOk: true,
+          racyCheckOk: true
+        }
+        if (playlistId.startsWith('RD') && currentVideoId) {
+          requestBody.videoId = currentVideoId
+        }
         const { body: playlistResponse, statusCode } = await makeRequest(
           `${apiEndpoint}/youtubei/v1/next`,
           {
@@ -202,12 +211,7 @@ export default class Web extends BaseClient {
               'User-Agent': this.getClient(context).client.userAgent,
               ...headers
             },
-            body: {
-              context: this.getClient(context),
-              playlistId,
-              contentCheckOk: true,
-              racyCheckOk: true
-            },
+            body: requestBody,
             method: 'POST',
             disableBodyCompression: true
           }


### PR DESCRIPTION
## Changes

The changes modify the request to the /next endpoint for radio playlists by adding videoId: currentVideoId to the body, which should make the API return tracks related to that video instead of unrelated content.


## Why 

This fix addresses the issue where radio playlist URLs were loading playlists with incorrect tracks, ensuring that the playlist contains relevant content based on the video ID in the URL.

## Checkmarks

- [ X ] The modified endpoints have been tested.
- [ X ] Used the same indentation as the rest of the project.
- [ X ] Still compatible with LavaLink clients.

## Additional information

Example, loading the playlist: https://www.youtube.com/watch?v=wlPbUqXyaZ4&list=RDWZQ6YKF_e4c&index=2, should return princess cuts my wrist as the first song, and them load songs related to it (ON THIS FIX)

before, if you add the same playlist, it would randomize to any song, and play a playlist that u never asked for or no songs related to it
