### PR TITLE
feat: player maintance

### DIFF
--- a/src/sources/youtube/clients/AndroidVR.js
+++ b/src/sources/youtube/clients/AndroidVR.js
@@ -15,9 +15,9 @@ export default class AndroidVR extends BaseClient {
     return {
       client: {
         clientName: 'ANDROID_VR',
-        clientVersion: '1.60.19',
+        clientVersion: '1.65.10',
         userAgent:
-          'com.google.android.apps.youtube.vr.oculus/1.60.19 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip',
+          'com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip',
         osName: 'Android',
         osVersion: '12L',
         androidSdkVersion: '32',

--- a/src/sources/youtube/clients/IOS.js
+++ b/src/sources/youtube/clients/IOS.js
@@ -17,7 +17,7 @@ export default class IOS extends BaseClient {
         clientName: 'IOS',
         clientVersion: '20.10.4',
         userAgent:
-          'com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3_2 like Mac OS X;',
+          'com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3_2 like Mac OS X;)',
         deviceMake: 'Apple',
         deviceModel: 'iPhone16,2',
         osName: 'iPhone',

--- a/src/sources/youtube/clients/IOS.js
+++ b/src/sources/youtube/clients/IOS.js
@@ -15,13 +15,13 @@ export default class IOS extends BaseClient {
     return {
       client: {
         clientName: 'IOS',
-        clientVersion: '19.47.7',
+        clientVersion: '20.10.4',
         userAgent:
-          'com.google.ios.youtube/19.47.7 (iPhone16,2; U; CPU iOS 17_5_1 like Mac OS X;)',
+          'com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3_2 like Mac OS X;',
         deviceMake: 'Apple',
         deviceModel: 'iPhone16,2',
         osName: 'iPhone',
-        osVersion: '17.5.1.21F90',
+        osVersion: '18.3.2.22D82',
         utcOffsetMinutes: 0,
         hl: context.client.hl,
         gl: context.client.gl,

--- a/src/sources/youtube/clients/TV.js
+++ b/src/sources/youtube/clients/TV.js
@@ -15,7 +15,7 @@ export default class TV extends BaseClient {
     return {
       client: {
         clientName: 'TVHTML5',
-        clientVersion: '7.20250319.10.00',
+        clientVersion: '7.20250923.13.00',
         userAgent: 'Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version',
         hl: context.client.hl,
         gl: context.client.gl

--- a/src/sources/youtube/clients/Web.js
+++ b/src/sources/youtube/clients/Web.js
@@ -15,10 +15,10 @@ export default class Web extends BaseClient {
     return {
       client: {
         clientName: 'WEB',
-        clientVersion: '2.20250403.01.00',
+        clientVersion: '2.20251030.01.00',
         platform: 'DESKTOP',
         userAgent:
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36',
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36,gzip(gfe)',
         hl: context.client.hl,
         gl: context.client.gl
       },


### PR DESCRIPTION
## Changes

This updates players like TV, ANDROID_VR, IOS and WEB to their latest user-agents / versions

## Why 

this can help with decompressing, since some user-agents have added gzip(gfe). This can also prevent more detections from using 'older' clients

## Checkmarks

- [ X ] The modified endpoints have been tested.
- [ X ] Used the same indentation as the rest of the project.
- [ X ] Still compatible with LavaLink clients.

## Additional information
