### PR TITLE
refactor: drop joi usage and move to myzod for a performance boost.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@performanc/voice": "github:PerformanC/voice",
     "@wasm-audio-decoders/flac": "^0.2.10",
     "@wasm-audio-decoders/ogg-vorbis": "^0.1.20",
-    "joi": "^18.0.1",
+    "myzod": "^1.12.1",
     "mp4box": "^2.1.2",
     "mpg123-decoder": "^1.0.3",
     "opusscript": "^0.0.8",

--- a/src/api/decodeTrack.js
+++ b/src/api/decodeTrack.js
@@ -1,4 +1,4 @@
-import Joi from 'joi'
+import myzod from 'myzod'
 import {
   decodeTrack,
   logger,
@@ -6,32 +6,30 @@ import {
   sendErrorResponse
 } from '../utils.js'
 
-const decodeTrackSchema = Joi.object({
-  encodedTrack: Joi.string().required().messages({
-    'string.empty': 'encodedTrack parameter cannot be empty.',
-    'any.required': 'Missing encodedTrack parameter.'
-  })
+const decodeTrackSchema = myzod.object({
+  encodedTrack: myzod.string()
 })
 
 function handler(nodelink, req, res, parsedUrl) {
-  const { error, value } = decodeTrackSchema.validate({
+  const result = decodeTrackSchema.try({
     encodedTrack: parsedUrl.searchParams.get('encodedTrack')
   })
 
-  if (error) {
+  if (result instanceof myzod.ValidationError) {
+    const errorMessage = result.message || 'Missing encodedTrack parameter.'
     sendErrorResponse(
       req,
       res,
       400,
       'Bad Request',
-      error.details[0].message,
+      errorMessage,
       parsedUrl.pathname,
       true
     )
     return
   }
 
-  const encodedTrack = value.encodedTrack
+  const encodedTrack = result.encodedTrack
 
   try {
     logger('debug', 'Tracks', `Decoding track: ${encodedTrack}`)

--- a/src/api/decodeTracks.js
+++ b/src/api/decodeTracks.js
@@ -1,4 +1,4 @@
-import Joi from 'joi'
+import myzod from 'myzod'
 import {
   decodeTrack,
   logger,
@@ -6,34 +6,26 @@ import {
   sendErrorResponse
 } from '../utils.js'
 
-const decodeTracksSchema = Joi.array()
-  .items(Joi.string().required())
-  .min(1)
-  .messages({
-    'array.base': 'encodedTracks parameter must be an array.',
-    'array.empty': 'encodedTracks parameter cannot be an empty array.',
-    'array.min': 'encodedTracks parameter cannot be an empty array.',
-    'string.base': 'Each item in encodedTracks must be a string.',
-    'any.required': 'encodedTracks parameter is required.'
-  })
+const decodeTracksSchema = myzod.array(myzod.string()).min(1)
 
 function handler(nodelink, req, res, sendResponse, parsedUrl) {
-  const { error, value } = decodeTracksSchema.validate(req.body)
+  const result = decodeTracksSchema.try(req.body)
 
-  if (error) {
+  if (result instanceof myzod.ValidationError) {
+    const errorMessage = result.message || 'encodedTracks parameter must be a non-empty array of strings.'
     sendErrorResponse(
       req,
       res,
       400,
       'Invalid request',
-      error.details[0].message,
+      errorMessage,
       parsedUrl.pathname,
       true
     )
     return
   }
 
-  const encodedTracks = value // Joi já validou e retornou o array
+  const encodedTracks = result
 
   const decodedTracks = []
   logger('debug', 'Tracks', `Decoding ${encodedTracks.length} tracks.`)

--- a/src/api/encodeTrack.js
+++ b/src/api/encodeTrack.js
@@ -1,36 +1,35 @@
-import Joi from 'joi'
+import myzod from 'myzod'
 import {
   encodeTrack,
   logger,
   sendResponse,
   sendErrorResponse
 } from '../utils.js'
-const encodeTrackSchema = Joi.object({
-  track: Joi.string().required().messages({
-    'string.empty': 'track parameter cannot be empty.',
-    'any.required': 'Missing track parameter.'
-  })
+
+const encodeTrackSchema = myzod.object({
+  track: myzod.string()
 })
 
 function handler(nodelink, req, res, sendResponse, parsedUrl) {
-  const { error, value } = encodeTrackSchema.validate({
+  const result = encodeTrackSchema.try({
     track: parsedUrl.searchParams.get('track')
   })
 
-  if (error) {
+  if (result instanceof myzod.ValidationError) {
+    const errorMessage = result.message || 'Missing track parameter.'
     sendErrorResponse(
       req,
       res,
       400,
       'Bad Request',
-      error.details[0].message,
+      errorMessage,
       parsedUrl.pathname,
       true
     )
     return
   }
 
-  const track = value.track
+  const track = result.track
 
   try {
     logger('debug', 'Tracks', `Encoding track: ${track}`)

--- a/src/api/encodedTracks.js
+++ b/src/api/encodedTracks.js
@@ -1,4 +1,4 @@
-import Joi from 'joi'
+import myzod from 'myzod'
 import {
   encodeTrack,
   logger,
@@ -6,39 +6,33 @@ import {
   sendErrorResponse
 } from '../utils.js'
 
-const encodedTracksSchema = Joi.array()
-  .items(
-    Joi.object({
-      encoded: Joi.string().required(),
-      info: Joi.object().required()
-    }).unknown(true) // Permitir outras propriedades no objeto track
+const encodedTracksSchema = myzod
+  .array(
+    myzod.object({
+      encoded: myzod.string(),
+      info: myzod.object({}).allowUnknownKeys()
+    }).allowUnknownKeys()
   )
   .min(1)
-  .messages({
-    'array.base': 'tracks parameter must be an array.',
-    'array.empty': 'tracks parameter cannot be an empty array.',
-    'array.min': 'tracks parameter cannot be an empty array.',
-    'string.base': 'Each item in tracks must be a string.',
-    'any.required': 'tracks parameter is required.'
-  })
 
 function handler(nodelink, req, res, sendResponse, parsedUrl) {
-  const { error, value } = encodedTracksSchema.validate(req.body)
+  const result = encodedTracksSchema.try(req.body)
 
-  if (error) {
+  if (result instanceof myzod.ValidationError) {
+    const errorMessage = result.message || 'tracks parameter must be an array and cannot be empty.'
     sendErrorResponse(
       req,
       res,
       400,
       'Invalid request',
-      error.details[0].message,
+      errorMessage,
       parsedUrl.pathname,
       true
     )
     return
   }
 
-  const tracks = value
+  const tracks = result
 
   const encodedTracks = []
   logger('debug', 'Tracks', `Encoding ${tracks.length} tracks.`)

--- a/src/api/loadLyrics.js
+++ b/src/api/loadLyrics.js
@@ -1,4 +1,4 @@
-import Joi from 'joi'
+import myzod from 'myzod'
 import {
   decodeTrack,
   logger,
@@ -6,31 +6,29 @@ import {
   sendErrorResponse
 } from '../utils.js'
 
-const loadLyricsSchema = Joi.object({
-  encodedTrack: Joi.string().required().messages({
-    'string.empty': 'encodedTrack parameter cannot be empty.',
-    'any.required': 'Missing encodedTrack parameter.'
-  })
+const loadLyricsSchema = myzod.object({
+  encodedTrack: myzod.string()
 })
 
 async function handler(nodelink, req, res, sendResponse, parsedUrl) {
-  const { error, value } = loadLyricsSchema.validate({
+  const result = loadLyricsSchema.try({
     encodedTrack: parsedUrl.searchParams.get('encodedTrack')
   })
 
-  if (error) {
-    logger('warn', 'Lyrics', error.details[0].message)
+  if (result instanceof myzod.ValidationError) {
+    const errorMessage = result.message || 'Missing encodedTrack parameter.'
+    logger('warn', 'Lyrics', errorMessage)
     return sendErrorResponse(
       req,
       res,
       400,
       'Bad Request',
-      error.details[0].message,
+      errorMessage,
       parsedUrl.pathname
     )
   }
 
-  const encodedTrack = value.encodedTrack
+  const encodedTrack = result.encodedTrack
 
   try {
     const decodedTrack = decodeTrack(encodedTrack)

--- a/src/api/loadTracks.js
+++ b/src/api/loadTracks.js
@@ -1,32 +1,30 @@
-import Joi from 'joi'
+import myzod from 'myzod'
 import { logger, sendResponse, sendErrorResponse } from '../utils.js'
 
-const loadTracksSchema = Joi.object({
-  identifier: Joi.string().required().messages({
-    'string.empty': 'identifier parameter cannot be empty.',
-    'any.required': 'identifier parameter is required.'
-  })
+const loadTracksSchema = myzod.object({
+  identifier: myzod.string()
 })
 
 async function handler(nodelink, req, res, sendResponse, parsedUrl) {
-  const { error, value } = loadTracksSchema.validate({
+  const result = loadTracksSchema.try({
     identifier: parsedUrl.searchParams.get('identifier')
   })
 
-  if (error) {
-    logger('warn', 'Tracks', error.details[0].message)
+  if (result instanceof myzod.ValidationError) {
+    const errorMessage = result.message || 'identifier parameter is required.'
+    logger('warn', 'Tracks', errorMessage)
     return sendErrorResponse(
       req,
       res,
       400,
       'missing identifier parameter',
-      error.details[0].message,
+      errorMessage,
       parsedUrl.pathname,
       true
     )
   }
 
-  const identifier = value.identifier
+  const identifier = result.identifier
   logger('debug', 'Tracks', `Loading tracks with identifier: "${identifier}"`)
 
   try {

--- a/src/api/routeplanner.js
+++ b/src/api/routeplanner.js
@@ -1,4 +1,4 @@
-import Joi from 'joi'
+import myzod from 'myzod'
 import { sendResponse, sendErrorResponse } from '../utils.js'
 
 function getStatus(nodelink, req, res) {
@@ -38,28 +38,26 @@ function getStatus(nodelink, req, res) {
   sendResponse(req, res, status, 200)
 }
 
-const freeAddressSchema = Joi.object({
-  address: Joi.string().required().messages({
-    'string.empty': 'The address field cannot be empty.',
-    'any.required': 'The address field is required.'
-  })
+const freeAddressSchema = myzod.object({
+  address: myzod.string()
 })
 
 function freeAddress(nodelink, req, res) {
-  const { error, value } = freeAddressSchema.validate(req.body)
+  const result = freeAddressSchema.try(req.body)
 
-  if (error) {
+  if (result instanceof myzod.ValidationError) {
+    const errorMessage = result.message || 'The address field is required.'
     return sendErrorResponse(
       req,
       res,
       400,
       'Bad Request',
-      error.details[0].message,
+      errorMessage,
       req.url
     )
   }
 
-  const { address } = value
+  const { address } = result
 
   nodelink.routePlanner.freeIP(address)
   res.writeHead(204)

--- a/src/api/sessions.id.js
+++ b/src/api/sessions.id.js
@@ -1,4 +1,4 @@
-import Joi from 'joi'
+import myzod from 'myzod'
 import {
   decodeTrack,
   logger,
@@ -6,16 +6,10 @@ import {
   sendErrorResponse
 } from '../utils.js'
 
-const sessionPatchSchema = Joi.object({
-  resuming: Joi.boolean().optional().messages({
-    'boolean.base': 'The resuming value must be a boolean.'
-  }),
-  timeout: Joi.number().integer().min(0).optional().messages({
-    'number.base': 'The timeout value must be a number.',
-    'number.integer': 'The timeout value must be an integer.',
-    'number.min': 'The timeout value must be a non-negative number.'
-  })
-})
+const sessionPatchSchema = myzod.object({
+  resuming: myzod.boolean().optional(),
+  timeout: myzod.number().min(0).optional()
+}).allowUnknownKeys()
 
 async function handler(nodelink, req, res, sendResponse, parsedUrl) {
   const parts = parsedUrl.pathname.split('/')
@@ -37,25 +31,26 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
     parsedUrl.pathname === `/v4/sessions/${sessionId}` &&
     req.method === 'PATCH'
   ) {
-    const { error, value } = sessionPatchSchema.validate(req.body)
+    const result = sessionPatchSchema.try(req.body)
 
-    if (error) {
+    if (result instanceof myzod.ValidationError) {
+      const errorMessage = result.message || 'Invalid PATCH payload'
       logger(
         'warn',
         'Session',
-        `Invalid PATCH payload for session ${sessionId}: ${error.details[0].message}`
+        `Invalid PATCH payload for session ${sessionId}: ${errorMessage}`
       )
       return sendErrorResponse(
         req,
         res,
         400,
         'Bad Request',
-        error.details[0].message,
+        errorMessage,
         parsedUrl.pathname
       )
     }
 
-    const payload = value
+    const payload = result
     logger(
       'debug',
       'Session',

--- a/src/api/sessions.id.players.js
+++ b/src/api/sessions.id.players.js
@@ -1,44 +1,43 @@
-import Joi from 'joi'
+import myzod from 'myzod'
 import { decodeTrack, logger, sendErrorResponse } from '../utils.js'
 
-const filtersSchema = Joi.object().unknown(true)
+// Use unknown() instead of object for filters to preserve all properties
+const filtersSchema = myzod.unknown()
 
-const voiceStateSchema = Joi.object({
-  token: Joi.string().required(),
-  endpoint: Joi.string().required(),
-  sessionId: Joi.string().required()
-}).unknown(true)
+const voiceStateSchema = myzod.object({
+  token: myzod.string(),
+  endpoint: myzod.string(),
+  sessionId: myzod.string()
+}).allowUnknownKeys()
 
-const updatePlayerTrackSchema = Joi.object({
-  encoded: Joi.string().allow(null).optional(),
-  identifier: Joi.string().optional(),
-  userData: Joi.object().unknown(true).optional()
-})
-  .xor('encoded', 'identifier')
-  .unknown(true)
+const updatePlayerTrackSchema = myzod.object({
+  encoded: myzod.string().nullable().optional(),
+  identifier: myzod.string().optional(),
+  userData: myzod.unknown().optional()
+}).allowUnknownKeys()
 
-const updatePlayerSchema = Joi.object({
+const updatePlayerSchema = myzod.object({
   track: updatePlayerTrackSchema.optional(),
-  encodedTrack: Joi.string().allow(null).optional(),
-  position: Joi.number().integer().min(0).optional(),
-  endTime: Joi.number().integer().min(0).allow(null).optional(),
-  volume: Joi.number().integer().min(0).max(1000).optional(),
-  paused: Joi.boolean().optional(),
+  encodedTrack: myzod.string().nullable().optional(),
+  position: myzod.number().min(0).optional(),
+  endTime: myzod.number().min(0).nullable().optional(),
+  volume: myzod.number().min(0).max(1000).optional(),
+  paused: myzod.boolean().optional(),
   filters: filtersSchema.optional(),
-  voice: voiceStateSchema.optional()
-})
-  .min(1)
-  .unknown(true)
+  voice: voiceStateSchema.optional(),
+  guildId: myzod.string().optional()
+}).allowUnknownKeys()
 
-const queryParamsSchema = Joi.object({
-  noReplace: Joi.boolean().empty(null).default(false)
-}).unknown(true)
+const queryParamsSchema = myzod.object({
+  noReplace: myzod.string().optional()
+}).allowUnknownKeys()
 
-const pathSchema = Joi.object({
-  sessionId: Joi.string().required(),
-  guildId: Joi.string()
-    .regex(/^\d{17,20}$/)
-    .optional()
+const pathSchema = myzod.object({
+  sessionId: myzod.string(),
+  guildId: myzod.string().withPredicate(
+    (val) => /^\d{17,20}$/.test(val),
+    'guildId must be 17-20 digits'
+  ).optional()
 })
 
 async function handler(nodelink, req, res, sendResponse, parsedUrl) {
@@ -48,26 +47,22 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
     guildId: parts[5]
   }
 
-  const { error: pathError, value: validatedParams } =
-    pathSchema.validate(pathParams)
+  const pathResult = pathSchema.try(pathParams)
 
-  if (pathError) {
-    logger(
-      'warn',
-      'PlayerUpdate',
-      `Invalid path parameters: ${pathError.details[0].message}`
-    )
+  if (pathResult instanceof myzod.ValidationError) {
+    const errorMessage = pathResult.message || 'Invalid path parameters'
+    logger('warn', 'PlayerUpdate', `Invalid path parameters: ${errorMessage}`)
     return sendErrorResponse(
       req,
       res,
       400,
       'Bad Request',
-      pathError.details[0].message,
+      errorMessage,
       parsedUrl.pathname
     )
   }
 
-  const { sessionId, guildId } = validatedParams
+  const { sessionId, guildId } = pathResult
   const session = nodelink.sessions.get(sessionId)
 
   if (!session) {
@@ -106,42 +101,43 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
       }
 
       if (req.method === 'PATCH') {
-        const { error: bodyError, value: payload } =
-          updatePlayerSchema.validate(req.body)
+        const bodyResult = updatePlayerSchema.try(req.body)
 
-        if (bodyError) {
+        if (bodyResult instanceof myzod.ValidationError) {
+          const errorMessage = bodyResult.message || 'Invalid payload'
           logger(
             'warn',
             'PlayerUpdate',
-            `Invalid payload for guild ${guildId}:`,
-            bodyError.details[0].message
+            `Invalid payload for guild ${guildId}: ${errorMessage}`
           )
           return sendErrorResponse(
             req,
             res,
             400,
             'Bad Request',
-            bodyError.details[0].message,
+            errorMessage,
             parsedUrl.pathname
           )
         }
 
-        const { error: queryError, value: query } = queryParamsSchema.validate({
+        const payload = bodyResult
+
+        const queryResult = queryParamsSchema.try({
           noReplace: parsedUrl.searchParams.get('noReplace')
         })
 
-        if (queryError) {
+        if (queryResult instanceof myzod.ValidationError) {
           return sendErrorResponse(
             req,
             res,
             400,
             'Bad Request',
-            queryError.details[0].message,
+            queryResult.message,
             parsedUrl.pathname
           )
         }
 
-        const { noReplace } = query
+        const noReplace = queryResult.noReplace === 'true'
 
         logger(
           'debug',


### PR DESCRIPTION
## Changes

This commit replaces the npm package 'joi' for validations with myzod, this should provide a performance boost in speed and lower overhead in memory for long-processes

current tests that me and lucas did:

loading a track/decoding with joi: 400-600 ms per request
loading a track/decoding with myzod: 113 - 130ms per request

resolving a 500 tracks playlist (spotify)
resolving with joi: took 1.7s
resolving with myzod: took 1.2s

## Why 

This pr provides a performance boost in speed, making the overall usage of nodelink faster for the users and resolving speeds, while also not breaking cluster communication.

## Checkmarks

- [ X ] The modified endpoints have been tested.
- [ X ] Used the same indentation as the rest of the project.
- [ X ] Still compatible with LavaLink clients.

## Additional information

Needs extra testing, any feedback is important to me atm
all endoints was tested with **POSTMAN**
