### PR TITLE
add: bun support

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
     "@wasm-audio-decoders/flac": "^0.2.10",
     "@wasm-audio-decoders/ogg-vorbis": "^0.1.20",
     "myzod": "^1.12.1",
-    "mp4box": "^2.1.2",
+    "mp4box": "^2.2.0",
     "mpg123-decoder": "^1.0.3",
     "opusscript": "^0.0.8",
     "prism-media": "^1.3.5",
     "sodium-native": "^5.0.9"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.2",
+    "@biomejs/biome": "^2.3.4",
     "dotenv": "^17.2.3"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -289,10 +289,15 @@ class NodelinkServer {
           'Server',
           `\x1b[36m${clientInfo.name}\x1b[0m/\x1b[32mv${clientInfo.version}\x1b[0m connected from ${clientAddress} | \x1b[33mURL:\x1b[0m ${request.url}`
         )
-
-        this.socket.handleUpgrade(request, socket, head, {}, (ws) =>
-          this.socket.emit('/v4/websocket', ws, request, clientInfo, sessionId)
-        )
+        if (process.isBun) {
+          this.socket.handleUpgrade(request, socket, head, (ws) =>
+            this.socket.emit('/v4/websocket', ws, request, clientInfo, sessionId)
+          )
+        } else {
+          this.socket.handleUpgrade(request, socket, head, {}, (ws) =>
+            this.socket.emit('/v4/websocket', ws, request, clientInfo, sessionId)
+          )
+        }
       } else {
         logger(
           'warn',
@@ -499,7 +504,7 @@ class NodelinkServer {
         try {
           try {
             handle.pause?.()
-          } catch (e) {}
+          } catch (e) { }
           this.server.emit('connection', handle)
         } catch (err) {
           logger(
@@ -509,7 +514,7 @@ class NodelinkServer {
           )
           try {
             handle.destroy?.()
-          } catch (e) {}
+          } catch (e) { }
         }
       })
     } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -153,14 +153,22 @@ function sendResponse(req, res, data, status, trace = false) {
 
   let finalData = data
   if (data.trace && !trace) {
-    const { trace, ...rest } = data
+    const { trace: _, ...rest } = data
     finalData = rest
   }
 
   headers['Content-Type'] = 'application/json'
   const jsonData = JSON.stringify(finalData)
-
+  const buffer = Buffer.from(jsonData)
   const encoding = req.headers['accept-encoding'] || ''
+
+  if (process.isBun) {
+    headers['Content-Length'] = buffer.byteLength
+    res.writeHead(status, headers)
+    res.end(buffer)
+    return
+  }
+
   const compressions = [
     { type: 'br', method: zlib.brotliCompress },
     { type: 'gzip', method: zlib.gzip },
@@ -170,11 +178,14 @@ function sendResponse(req, res, data, status, trace = false) {
   for (const { type, method } of compressions) {
     if (encoding.includes(type)) {
       headers['Content-Encoding'] = type
-      method(jsonData, (err, result) => {
+      method(buffer, (err, result) => {
         if (err) {
-          res.writeHead(500, {})
-          res.end()
+          res.writeHead(500, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: 'Compression failed' }))
           return
+        }
+        if (process.isBun) {
+          headers['Content-Length'] = result.byteLength
         }
         res.writeHead(status, headers)
         res.end(result)
@@ -183,8 +194,9 @@ function sendResponse(req, res, data, status, trace = false) {
     }
   }
 
+  headers['Content-Length'] = buffer.byteLength
   res.writeHead(status, headers)
-  res.end(jsonData)
+  res.end(buffer)
 }
 
 function getGitInfo() {


### PR DESCRIPTION
## Changes

Updated utils (for sendResponse bun's structure request compatibility) and updated index.js to correctly handle bun's websocket

## Why 

This should improve nodelink's platforms, while bun can also be more performant and faster than nodejs sometimes.

## Checkmarks

- [ X ] The modified endpoints have been tested.
- [ X ] Used the same indentation as the rest of the project.
- [ X ] Still compatible with LavaLink clients.

## Additional information

Pending fixes from pwsl websocket and voice.