### PR TITLE
Add Apple Music Source Support + Apple Music Lyrics Retrieval

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -179,7 +179,8 @@ export default {
       enabled: true
     },
     applemusic: {
-      enabled: true
+      enabled: true,
+      advanceSearch: true // Uses YTMusic to fetch the correct title and artists instead of relying on messy YouTube video titles, improving lyrics accuracy
     },
   },
   audio: {

--- a/config.default.js
+++ b/config.default.js
@@ -167,7 +167,10 @@ export default {
     },
     lrclib: {
       enabled: true
-    }
+    },
+     applemusic: {
+      enabled: true
+    },
   },
   audio: {
     encryption: 'aead_aes256_gcm_rtpsize'

--- a/config.default.js
+++ b/config.default.js
@@ -136,6 +136,16 @@ export default {
       albumPageLoadConcurrency: 5, // How many pages to load simultaneously
       allowExplicit: true // If true plays the explicit version of the song, If false plays the Non-Explicit version of the song. Normal songs are not affected.
     },
+    applemusic: {
+      enabled: true,
+      mediaApiToken: "token_here", // use https://github.com/CycloneAddons/apple-music-token-scraper to get a token
+      market: "US",
+      playlistLoadLimit: 0,
+      albumLoadLimit: 0,
+      playlistPageLoadConcurrency: 5,
+      albumPageLoadConcurrency: 5,
+      allowExplicit: true
+    },
     tidal: {
       enabled: true,
       token: '', //get from tidal web player devtools; using login google account
@@ -168,7 +178,7 @@ export default {
     lrclib: {
       enabled: true
     },
-     applemusic: {
+    applemusic: {
       enabled: true
     },
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@performanc/voice": "github:PerformanC/voice",
     "@wasm-audio-decoders/flac": "^0.2.10",
     "@wasm-audio-decoders/ogg-vorbis": "^0.1.20",
-    "fuse.js": "^7.1.0",
     "mp4box": "^2.2.0",
     "mpg123-decoder": "^1.0.3",
     "myzod": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@performanc/voice": "github:PerformanC/voice",
     "@wasm-audio-decoders/flac": "^0.2.10",
     "@wasm-audio-decoders/ogg-vorbis": "^0.1.20",
+    "fuse.js": "^7.1.0",
     "mp4box": "^2.2.0",
     "mpg123-decoder": "^1.0.3",
     "myzod": "^1.12.1",

--- a/src/lyrics/applemusic.js
+++ b/src/lyrics/applemusic.js
@@ -1,5 +1,4 @@
 import { logger, makeRequest } from '../utils.js'
-import Fuse from 'fuse.js'
 
 
 const APPLE_SEARCH_API = `http://lyrics.paxsenix.dpdns.org/searchAppleMusic.php?q=`
@@ -102,22 +101,119 @@ export default class AppleMusicLyrics {
     }
   }
 
-  async _searchApple(query) {
 
-    const url = APPLE_SEARCH_API + encodeURIComponent(query)
-    const { body: raw_results } = await makeRequest(url, { method: 'GET' })
-    let results = JSON.parse(raw_results)
 
-    if (!Array.isArray(results) || results.length === 0) return null
+  _findBestAppleMatch(results, title, authors) {
+    if (!title) return results[0];
 
-    const fuse = new Fuse(results, {
-      includeScore: true,
-      keys: ['songName', 'artistName'],
-      threshold: 0.4
-    })
+    const normalize = (str) =>
+      str.toLowerCase()
+        .replace(/[^a-z0-9]+/gi, " ")
+        .trim();
 
-    const found = fuse.search(query)
-    return found.length ? found[0].item : results[0]
+    const scoreStrings = (a, b) => {
+      a = normalize(a);
+      b = normalize(b);
+      if (a === b) return 100;
+      let matches = 0;
+      const len = Math.max(a.length, b.length);
+
+      for (let i = 0; i < Math.min(a.length, b.length); i++) {
+        if (a[i] === b[i]) matches++;
+      }
+
+      return Math.round((matches / len) * 100);
+    };
+
+    let bestMatch = null;
+    let bestScore = -1;
+
+    for (const r of results) {
+      const titleScore = scoreStrings(r.songName, title);
+
+      let artistScore = 0;
+
+      if (authors.length) {
+        artistScore = Math.max(
+          ...authors.map(a => scoreStrings(r.artistName, a))
+        );
+      }
+
+      const finalScore = titleScore * 0.7 + artistScore * 0.3;
+
+      r.__matchScore = finalScore;
+
+      if (finalScore > bestScore) {
+        bestScore = finalScore;
+        bestMatch = r;
+      }
+    }
+
+    return bestMatch;
+  }
+
+
+
+  async _searchApple(info) {
+    let title = null;
+    let authors = [];
+
+    if (info.sourceName === "youtube") {
+      try {
+        const { body: res } = await makeRequest(
+          `https://ytm-api-nodelink.vercel.app/api/song-info?videoId=${encodeURIComponent(info.identifier)}`,
+          { method: 'GET', timeout: 4000 }
+        );
+
+        if (res && res.title) {
+         if(info.title !== res.title) { title = res.title } else { title = _clean(info.title, true)};
+          authors = Array.isArray(res.artists) ? res.artists : [];
+        } else {
+          logger('warn', 'Lyrics', "AppleMusic: YTM API returned invalid data, using fallback.");
+        }
+      } catch (err) {
+        logger('error', 'Lyrics', `AppleMusic: YTM API failed (${err.message}), using fallback info.`);
+      }
+    }
+
+
+    const query = (() => {
+      if (title && authors.length) return `${title} ${authors[0]}`;
+      if (title) return title;
+      return `${_clean(info.title, true)} ${_clean(info.author, false)}`;
+    })();
+
+    let results;
+
+    try {
+      const url = APPLE_SEARCH_API + encodeURIComponent(query);
+      const { body: raw_results } = await makeRequest(url, { method: 'GET', timeout: 4000 });
+      results = JSON.parse(raw_results);
+    } catch (err) {
+      logger('error', 'Lyrics', `AppleMusic: Apple search failed (${err.message})`);
+      return null;
+    }
+
+    if (!Array.isArray(results) || results.length === 0) {
+      logger('warn', 'Lyrics', "AppleMusic: No results returned.");
+      return null;
+    }
+
+    let best = null;
+
+    try {
+      best = this._findBestAppleMatch(results, _clean(title), authors);
+    } catch (err) {
+      logger('error', 'Lyrics', `AppleMusic: Matching failed (${err.message})`);
+    }
+
+    if (!best) {
+      logger('warn', 'Lyrics', "AppleMusic: No strong match, falling back to top result.");
+      return results[0];
+    }
+
+    logger('info', 'Lyrics', `AppleMusic: Best Match Selected => ${JSON.stringify(best)}`);
+    return best;
   }
 
   async getLyrics(trackInfo) {
@@ -133,16 +229,7 @@ export default class AppleMusicLyrics {
       }
 
       if (!songID) {
-        const parsed = _parse(trackInfo.title)
-        const cleanAuthor = _clean(trackInfo.author, false)
-
-        const artist = parsed.artist || cleanAuthor
-        const title = parsed.artist ? parsed.title : _clean(trackInfo.title, true)
-        const query = `${title} ${artist}`
-
-        logger('debug', 'Lyrics', `AppleMusic: Searching: ${query}`)
-
-        matchedTrack = await this._searchApple(query)
+        matchedTrack = await this._searchApple(trackInfo)
         if (!matchedTrack) {
           return { loadType: 'empty', data: {} }
         }

--- a/src/lyrics/applemusic.js
+++ b/src/lyrics/applemusic.js
@@ -1,9 +1,7 @@
 import { logger, makeRequest } from '../utils.js'
 
-
 const APPLE_SEARCH_API = `http://lyrics.paxsenix.dpdns.org/searchAppleMusic.php?q=`
 const APPLE_LYRICS_API = `http://lyrics.paxsenix.dpdns.org/getAppleMusicLyrics.php?id=`
-
 
 const CLEAN_PATTERNS = [
   /\s*\([^)]*(?:official|lyrics?|video|audio|mv|visualizer|color\s*coded|hd|4k|prod\.)[^)]*\)/gi,
@@ -12,9 +10,7 @@ const CLEAN_PATTERNS = [
   /VEVO$/i
 ]
 
-const FEAT_PATTERN =
-  /\s*[\(\[]\s*(?:ft\.?|feat\.?|featuring)\s+[^\)\]]+[\)\]]/gi
-
+const FEAT_PATTERN = /\s*[\(\[]\s*(?:ft\.?|feat\.?|featuring)\s+[^\)\]]+[\)\]]/gi
 const SEPARATORS = [' - ', ' – ', ' — ']
 
 const _clean = (text, removeFeat = false) => {
@@ -26,49 +22,182 @@ const _clean = (text, removeFeat = false) => {
 
 const _parse = (query) => {
   const cleaned = _clean(query, true)
-
   for (const sep of SEPARATORS) {
     const idx = cleaned.indexOf(sep)
     if (idx > 0 && idx < cleaned.length - sep.length) {
-      return {
-        artist: cleaned.slice(0, idx).trim(),
-        title: cleaned.slice(idx + sep.length).trim()
-      }
+      return { artist: cleaned.slice(0, idx).trim(), title: cleaned.slice(idx + sep.length).trim() }
+    }
+  }
+  return { artist: null, title: _clean(query, true) }
+}
+
+class YTMusic {
+  constructor() {
+    this.isReady = false
+    this.config = {}
+    this.baseUrl = 'https://music.youtube.com/'
+    this.defaultHeaders = {
+      'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.129 Safari/537.36',
+      'Accept-Language': 'en-US,en;q=0.5'
     }
   }
 
-  return {
-    artist: null,
-    title: _clean(query, true)
+  async initialize(options = {}) {
+    try {
+      const { GL, HL } = options
+      const { body: html } = await makeRequest(this.baseUrl, { method: 'GET', headers: this.defaultHeaders, timeout: 8000 })
+      const matches = html.match(/ytcfg\.set\(.*\)/) || [];
+      const parsed = matches
+        .map(x => x.slice(10, -1))
+        .map(x => { try { return JSON.parse(x) } catch { return null } })
+        .filter(Boolean)
+      this.config = parsed.reduce((acc, v) => ({ ...acc, ...v }), {})
+      if (GL) this.config.GL = GL
+      if (HL) this.config.HL = HL
+      if (!this.config.INNERTUBE_API_KEY) {
+        logger('error', 'YTMusic', 'Initialization failed: Missing required config')
+        return
+      }
+      this.isReady = true
+      logger('info', 'YTMusic', 'Initialized successfully')
+    } catch (e) {
+      logger('error', 'YTMusic', `Initialization error: ${e.message}`)
+    }
+  }
+
+  _buildHeaders() {
+    const headers = {
+      ...this.defaultHeaders,
+      'X-Goog-Visitor-Id': this.config.VISITOR_DATA || '',
+      'X-YouTube-Client-Name': this.config.INNERTUBE_CONTEXT_CLIENT_NAME,
+      'X-YouTube-Client-Version': this.config.INNERTUBE_CLIENT_VERSION,
+      'X-YouTube-Device': this.config.DEVICE,
+      'X-YouTube-Page-CL': this.config.PAGE_CL,
+      'X-YouTube-Page-Label': this.config.PAGE_BUILD_LABEL,
+      'X-YouTube-Utc-Offset': String(-new Date().getTimezoneOffset()),
+      'X-YouTube-Time-Zone': Intl.DateTimeFormat().resolvedOptions().timeZone
+    }
+    for (const k of Object.keys(headers)) {
+      if (headers[k] === undefined || headers[k] === null || headers[k] === '') delete headers[k]
+    }
+    return headers
+  }
+
+  async _post(endpoint, body = {}, query = {}) {
+    if (!this.isReady) throw new Error('YTMusic not initialized')
+    const params = new URLSearchParams({ alt: 'json', key: this.config.INNERTUBE_API_KEY, ...query }).toString()
+    const url = `${this.baseUrl}/youtubei/${this.config.INNERTUBE_API_VERSION || 'v1'}/${endpoint}?${params}`
+    const payload = {
+      context: {
+        capabilities: {},
+        client: {
+          clientName: this.config.INNERTUBE_CLIENT_NAME || this.config.INNERTUBE_CONTEXT_CLIENT_NAME || 'WEB_REMIX',
+          clientVersion: this.config.INNERTUBE_CLIENT_VERSION || '0.0.0',
+          experimentIds: [],
+          experimentsToken: '',
+          gl: this.config.GL,
+          hl: this.config.HL,
+          locationInfo: { locationPermissionAuthorizationStatus: 'LOCATION_PERMISSION_AUTHORIZATION_STATUS_UNSUPPORTED' },
+          musicAppInfo: {
+            musicActivityMasterSwitch: 'MUSIC_ACTIVITY_MASTER_SWITCH_INDETERMINATE',
+            musicLocationMasterSwitch: 'MUSIC_LOCATION_MASTER_SWITCH_INDETERMINATE',
+            pwaInstallabilityStatus: 'PWA_INSTALLABILITY_STATUS_UNKNOWN'
+          },
+          utcOffsetMinutes: -new Date().getTimezoneOffset()
+        },
+        request: {
+          internalExperimentFlags: [
+            { key: 'force_music_enable_outertube_tastebuilder_browse', value: 'true' },
+            { key: 'force_music_enable_outertube_playlist_detail_browse', value: 'true' },
+            { key: 'force_music_enable_outertube_search_suggestions', value: 'true' }
+          ]
+        },
+        user: { enableSafetyMode: false }
+      },
+      ...body
+    }
+    const headers = this._buildHeaders()
+    const { body: res } = await makeRequest(url, { method: 'POST', headers, body: payload, timeout: 8000 })
+    return res
+  }
+
+  async getSongInfo(videoId) {
+    if (!this.isReady) {
+      logger('warn', 'YTMusic', 'getSongInfo called before initialization')
+      return { title: null, artists: [], thumbnail: null, duration: null }
+    }
+    if (!videoId || typeof videoId !== 'string') {
+      logger('warn', 'YTMusic', 'Invalid videoId provided')
+      return { title: null, artists: [], thumbnail: null, duration: null }
+    }
+    try {
+      const body = {
+        enablePersistentPlaylistPanel: true,
+        tunerSettingValue: 'AUTOMIX_SETTING_NORMAL',
+        videoId,
+        isAudioOnly: true,
+        responsiveSignals: { videoInteraction: [] },
+        queueContextParams: ''
+      }
+      const data = await this._post('next', body, { prettyPrint: 'false' })
+      return extract(data)
+    } catch (e) {
+      logger('error', 'YTMusic', `getSongInfo error: ${e.message}`)
+      return { title: null, artists: [], thumbnail: null, duration: null }
+    }
+
+    function extract(data) {
+      try {
+        const contents = data.contents.singleColumnMusicWatchNextResultsRenderer
+          .tabbedRenderer.watchNextTabbedResultsRenderer.tabs[0]
+          .tabRenderer.content.musicQueueRenderer.content.playlistPanelRenderer.contents
+        const first = contents[0].playlistPanelVideoRenderer
+        const title = first.title?.runs?.[0]?.text || null
+        const artistRuns = first.longBylineText?.runs || []
+        const artists = artistRuns
+          .filter(r =>
+            r?.navigationEndpoint?.browseEndpoint?.browseEndpointContextSupportedConfigs
+              ?.browseEndpointContextMusicConfig?.pageType === 'MUSIC_PAGE_TYPE_ARTIST'
+          )
+          .map(r => r.text)
+        const thumbs = first.thumbnail?.thumbnails || []
+        const thumbnail = thumbs.length ? thumbs[thumbs.length - 1].url : null
+        const duration = first.lengthText?.runs?.[0]?.text || null
+        return { title, artists, thumbnail, duration }
+      } catch (e) {
+        logger('error', 'YTMusic', `extractSongInfo error: ${e.message}`)
+        return { title: null, artists: [], thumbnail: null, duration: null }
+      }
+    }
   }
 }
 
 export default class AppleMusicLyrics {
   constructor(nodelink) {
     this.nodelink = nodelink
+    this.config = nodelink.options
+    this.ytm = null
   }
 
   async setup() {
+    const adv = this.config.lyrics.applemusic?.advanceSearch || false
+    if (adv) {
+      this.ytm = new YTMusic()
+      await this.ytm.initialize({})
+      logger('info', 'Lyrics', 'Apple Music: Advanced search initialized')
+    }
     return true
   }
 
   _parseSynced(contentArray) {
     const lines = []
-
-    for (const entry of contentArray) {
-      const text = entry.text?.map(t => t.text).join(' ').trim()
-      if (!text) continue
-
-      const start = entry.timestamp ?? 0
-      const end = entry.endtime ?? 0
-
-      lines.push({
-        text,
-        time: start,
-        duration: Math.max(end - start, 0)
-      })
+    for (const e of contentArray) {
+      const txt = e.text?.map(t => t.text).join(' ').trim()
+      if (!txt) continue
+      const s = e.timestamp ?? 0
+      const ed = e.endtime ?? 0
+      lines.push({ text: txt, time: s, duration: Math.max(ed - s, 0) })
     }
-
     return lines
   }
 
@@ -76,191 +205,132 @@ export default class AppleMusicLyrics {
     try {
       const url = APPLE_LYRICS_API + id
       const { body } = await makeRequest(url, { method: 'GET' })
-
       if (!body) return null
-
       const synced = body.type === 'Line'
       let lines = []
-
       if (synced) {
         lines = this._parseSynced(body.content)
       } else {
         const raw = body.plainLyrics ?? ''
-        lines = raw
-          .split('\n')
-          .map(line => line.trim())
-          .filter(Boolean)
-          .map(text => ({ text, time: 0, duration: 0 }))
+        lines = raw.split('\n').map(l => l.trim()).filter(Boolean).map(t => ({ text: t, time: 0, duration: 0 }))
       }
-
       if (!lines.length) return null
-
       return { synced, lines }
     } catch {
       return null
     }
   }
 
-
-
   _findBestAppleMatch(results, title, authors) {
-    if (!title) return results[0];
-
-    const normalize = (str) =>
-      str.toLowerCase()
-        .replace(/[^a-z0-9]+/gi, " ")
-        .trim();
-
+    if (!title) return results[0]
+    const normalize = (s) => s.toLowerCase().replace(/[^a-z0-9]+/gi, ' ').trim()
     const scoreStrings = (a, b) => {
-      a = normalize(a);
-      b = normalize(b);
-      if (a === b) return 100;
-      let matches = 0;
-      const len = Math.max(a.length, b.length);
-
-      for (let i = 0; i < Math.min(a.length, b.length); i++) {
-        if (a[i] === b[i]) matches++;
-      }
-
-      return Math.round((matches / len) * 100);
-    };
-
-    let bestMatch = null;
-    let bestScore = -1;
-
+      a = normalize(a)
+      b = normalize(b)
+      if (a === b) return 100
+      let m = 0
+      const len = Math.max(a.length, b.length)
+      for (let i = 0; i < Math.min(a.length, b.length); i++) if (a[i] === b[i]) m++
+      return Math.round((m / len) * 100)
+    }
+    let best = null
+    let bestScore = -1
     for (const r of results) {
-      const titleScore = scoreStrings(r.songName, title);
-
-      let artistScore = 0;
-
-      if (authors.length) {
-        artistScore = Math.max(
-          ...authors.map(a => scoreStrings(r.artistName, a))
-        );
-      }
-
-      const finalScore = titleScore * 0.7 + artistScore * 0.3;
-
-      r.__matchScore = finalScore;
-
-      if (finalScore > bestScore) {
-        bestScore = finalScore;
-        bestMatch = r;
+      const ts = scoreStrings(r.songName, title)
+      let as = 0
+      if (authors.length) as = Math.max(...authors.map(a => scoreStrings(r.artistName, a)))
+      const final = ts * 0.7 + as * 0.3
+      r.__matchScore = final
+      if (final > bestScore) {
+        bestScore = final
+        best = r
       }
     }
-
-    return bestMatch;
+    return best
   }
 
-
-
   async _searchApple(info) {
-    let title = null;
-    let authors = [];
+    let title = null
+    let authors = []
+    if (info.sourceName === 'youtube') {
+      if (!this.ytm || !this.ytm.isReady) {
+        logger('warn', 'Lyrics', 'YTMusic not ready, skipping YTM fetch.')
+      } else {
+        try {
+          const res = await this.ytm.getSongInfo(info.identifier)
 
-    if (info.sourceName === "youtube") {
-      try {
-        const { body: res } = await makeRequest(
-          `https://ytm-api-nodelink.vercel.app/api/song-info?videoId=${encodeURIComponent(info.identifier)}`,
-          { method: 'GET', timeout: 4000 }
-        );
-
-        if (res && res.title) {
-         if(info.title !== res.title) { title = res.title } else { title = _clean(info.title, true)};
-          authors = Array.isArray(res.artists) ? res.artists : [];
-        } else {
-          logger('warn', 'Lyrics', "AppleMusic: YTM API returned invalid data, using fallback.");
+          if (res && res.title) {
+            title = info.title !== res.title ? res.title : _clean(info.title, true)
+            authors = Array.isArray(res.artists) ? res.artists : []
+          } else {
+            logger('warn', 'Lyrics', 'YTMusic returned invalid info, fallback used.')
+          }
+        } catch (err) {
+          logger('error', 'Lyrics', `YTMusic fetch failed: ${err.message}`)
         }
-      } catch (err) {
-        logger('error', 'Lyrics', `AppleMusic: YTM API failed (${err.message}), using fallback info.`);
       }
     }
 
-
     const query = (() => {
-      if (title && authors.length) return `${title} ${authors[0]}`;
-      if (title) return title;
-      return `${_clean(info.title, true)} ${_clean(info.author, false)}`;
-    })();
-
-    let results;
-
+      if (title && authors.length) return `${title} ${authors[0]}`
+      if (title) return title
+      return `${_clean(info.title, true)} ${_clean(info.author, false)}`
+    })()
+    let results
     try {
-      const url = APPLE_SEARCH_API + encodeURIComponent(query);
-      const { body: raw_results } = await makeRequest(url, { method: 'GET', timeout: 4000 });
-      results = JSON.parse(raw_results);
-    } catch (err) {
-      logger('error', 'Lyrics', `AppleMusic: Apple search failed (${err.message})`);
-      return null;
+      const url = APPLE_SEARCH_API + encodeURIComponent(query)
+      const { body: raw } = await makeRequest(url, { method: 'GET', timeout: 4000 })
+      results = JSON.parse(raw)
+    } catch (e) {
+      logger('error', 'Lyrics', `AppleMusic: Apple search failed (${e.message})`)
+      return null
     }
-
-    if (!Array.isArray(results) || results.length === 0) {
-      logger('warn', 'Lyrics', "AppleMusic: No results returned.");
-      return null;
+    if (!Array.isArray(results) || !results.length) {
+      logger('warn', 'Lyrics', 'AppleMusic: No results returned.')
+      return null
     }
-
-    let best = null;
-
+    let best = null
     try {
-      best = this._findBestAppleMatch(results, _clean(title), authors);
-    } catch (err) {
-      logger('error', 'Lyrics', `AppleMusic: Matching failed (${err.message})`);
+      best = this._findBestAppleMatch(results, _clean(title), authors)
+    } catch (e) {
+      logger('error', 'Lyrics', `Matching failed (${e.message})`)
     }
-
     if (!best) {
-      logger('warn', 'Lyrics', "AppleMusic: No strong match, falling back to top result.");
-      return results[0];
+      logger('warn', 'Lyrics', 'AppleMusic: No strong match, falling back.')
+      return results[0]
     }
 
-    logger('info', 'Lyrics', `AppleMusic: Best Match Selected => ${JSON.stringify(best)}`);
-    return best;
+    return best
   }
 
   async getLyrics(trackInfo) {
     try {
-      const isAppleSource = trackInfo.sourceName === 'applemusic'
-      let songID = null
-      let matchedTrack = null
-
-
-      if (isAppleSource && trackInfo.identifier) {
-        songID = trackInfo.identifier
-        logger('debug', 'Lyrics', `AppleMusic: Direct ID: ${songID}`)
+      const isApple = trackInfo.sourceName === 'applemusic'
+      let id = null
+      let matched = null
+      if (isApple && trackInfo.identifier) {
+        id = trackInfo.identifier
+        logger('debug', 'Lyrics', `AppleMusic: Direct ID: ${id}`)
       }
-
-      if (!songID) {
-        matchedTrack = await this._searchApple(trackInfo)
-        if (!matchedTrack) {
-          return { loadType: 'empty', data: {} }
-        }
-
-        songID = matchedTrack.id
+      if (!id) {
+        matched = await this._searchApple(trackInfo)
+        if (!matched) return { loadType: 'empty', data: {} }
+        id = matched.id
       }
-
-      const lyricObj = await this._getLyricsByID(songID)
-      if (!lyricObj) {
-        return { loadType: 'empty', data: {} }
-      }
-
-      const trackName =
-        matchedTrack?.songName || trackInfo.title
-
+      const lyr = await this._getLyricsByID(id)
+      if (!lyr) return { loadType: 'empty', data: {} }
+      const trackName = matched?.songName || trackInfo.title
       return {
         loadType: 'lyrics',
         data: {
           name: trackName,
-          synced: lyricObj.synced,
-          lines: lyricObj.lines
+          synced: lyr.synced,
+          lines: lyr.lines
         }
       }
-
     } catch (e) {
       logger('error', 'Lyrics', `AppleMusic error: ${e.message}`)
-
-      return {
-        loadType: 'error',
-        data: { message: e.message, severity: 'fault' }
-      }
+      return { loadType: 'error', data: { message: e.message, severity: 'fault' } }
     }
   }
 }

--- a/src/lyrics/applemusic.js
+++ b/src/lyrics/applemusic.js
@@ -1,0 +1,179 @@
+import { logger, makeRequest } from '../utils.js'
+import Fuse from 'fuse.js'
+
+
+const APPLE_SEARCH_API = `http://lyrics.paxsenix.dpdns.org/searchAppleMusic.php?q=`
+const APPLE_LYRICS_API = `http://lyrics.paxsenix.dpdns.org/getAppleMusicLyrics.php?id=`
+
+
+const CLEAN_PATTERNS = [
+  /\s*\([^)]*(?:official|lyrics?|video|audio|mv|visualizer|color\s*coded|hd|4k|prod\.)[^)]*\)/gi,
+  /\s*\[[^\]]*(?:official|lyrics?|video|audio|mv|visualizer|color\s*coded|hd|4k|prod\.)[^\]]*\]/gi,
+  /\s*-\s*Topic$/i,
+  /VEVO$/i
+]
+
+const FEAT_PATTERN =
+  /\s*[\(\[]\s*(?:ft\.?|feat\.?|featuring)\s+[^\)\]]+[\)\]]/gi
+
+const SEPARATORS = [' - ', ' – ', ' — ']
+
+const _clean = (text, removeFeat = false) => {
+  let result = text
+  for (const pattern of CLEAN_PATTERNS) result = result.replace(pattern, '')
+  if (removeFeat) result = result.replace(FEAT_PATTERN, '')
+  return result.trim()
+}
+
+const _parse = (query) => {
+  const cleaned = _clean(query, true)
+
+  for (const sep of SEPARATORS) {
+    const idx = cleaned.indexOf(sep)
+    if (idx > 0 && idx < cleaned.length - sep.length) {
+      return {
+        artist: cleaned.slice(0, idx).trim(),
+        title: cleaned.slice(idx + sep.length).trim()
+      }
+    }
+  }
+
+  return {
+    artist: null,
+    title: _clean(query, true)
+  }
+}
+
+export default class AppleMusicLyrics {
+  constructor(nodelink) {
+    this.nodelink = nodelink
+  }
+
+  async setup() {
+    return true
+  }
+
+  _parseSynced(contentArray) {
+    const lines = []
+
+    for (const entry of contentArray) {
+      const text = entry.text?.map(t => t.text).join(' ').trim()
+      if (!text) continue
+
+      const start = entry.timestamp ?? 0
+      const end = entry.endtime ?? 0
+
+      lines.push({
+        text,
+        time: start,
+        duration: Math.max(end - start, 0)
+      })
+    }
+
+    return lines
+  }
+
+  async _getLyricsByID(id) {
+    try {
+      const url = APPLE_LYRICS_API + id
+      const { body } = await makeRequest(url, { method: 'GET' })
+
+      if (!body) return null
+
+      const synced = body.type === 'Line'
+      let lines = []
+
+      if (synced) {
+        lines = this._parseSynced(body.content)
+      } else {
+        const raw = body.plainLyrics ?? ''
+        lines = raw
+          .split('\n')
+          .map(line => line.trim())
+          .filter(Boolean)
+          .map(text => ({ text, time: 0, duration: 0 }))
+      }
+
+      if (!lines.length) return null
+
+      return { synced, lines }
+    } catch {
+      return null
+    }
+  }
+
+  async _searchApple(query) {
+
+    const url = APPLE_SEARCH_API + encodeURIComponent(query)
+    const { body: raw_results } = await makeRequest(url, { method: 'GET' })
+    let results = JSON.parse(raw_results)
+
+    if (!Array.isArray(results) || results.length === 0) return null
+
+    const fuse = new Fuse(results, {
+      includeScore: true,
+      keys: ['songName', 'artistName'],
+      threshold: 0.4
+    })
+
+    const found = fuse.search(query)
+    return found.length ? found[0].item : results[0]
+  }
+
+  async getLyrics(trackInfo) {
+    try {
+      const isAppleSource = trackInfo.sourceName === 'applemusic'
+      let songID = null
+      let matchedTrack = null
+
+
+      if (isAppleSource && trackInfo.identifier) {
+        songID = trackInfo.identifier
+        logger('debug', 'Lyrics', `AppleMusic: Direct ID: ${songID}`)
+      }
+
+      if (!songID) {
+        const parsed = _parse(trackInfo.title)
+        const cleanAuthor = _clean(trackInfo.author, false)
+
+        const artist = parsed.artist || cleanAuthor
+        const title = parsed.artist ? parsed.title : _clean(trackInfo.title, true)
+        const query = `${title} ${artist}`
+
+        logger('debug', 'Lyrics', `AppleMusic: Searching: ${query}`)
+
+        matchedTrack = await this._searchApple(query)
+        if (!matchedTrack) {
+          return { loadType: 'empty', data: {} }
+        }
+
+        songID = matchedTrack.id
+      }
+
+      const lyricObj = await this._getLyricsByID(songID)
+      if (!lyricObj) {
+        return { loadType: 'empty', data: {} }
+      }
+
+      const trackName =
+        matchedTrack?.songName || trackInfo.title
+
+      return {
+        loadType: 'lyrics',
+        data: {
+          name: trackName,
+          synced: lyricObj.synced,
+          lines: lyricObj.lines
+        }
+      }
+
+    } catch (e) {
+      logger('error', 'Lyrics', `AppleMusic error: ${e.message}`)
+
+      return {
+        loadType: 'error',
+        data: { message: e.message, severity: 'fault' }
+      }
+    }
+  }
+}

--- a/src/sources/applemusic.js
+++ b/src/sources/applemusic.js
@@ -1,0 +1,427 @@
+import { encodeTrack, http1makeRequest, logger } from '../utils.js'
+
+const API_BASE = 'https://api.music.apple.com/v1'
+const MAX_PAGE_ITEMS = 300
+const DURATION_TOLERANCE = 0.15
+const BATCH_SIZE_DEFAULT = 5
+
+export default class AppleMusicSource {
+    constructor(nodelink) {
+        this.nodelink = nodelink
+        this.config = nodelink.options
+        this.searchTerms = ['amsearch']
+
+        this.patterns = [
+            /https?:\/\/(?:www\.)?music\.apple\.com\/(?:[a-zA-Z]{2}\/)?(album|playlist|artist|song)\/[^/]+\/([a-zA-Z0-9\-.]+)(?:\?i=(\d+))?/
+        ]
+
+        this.priority = 95
+
+        this.mediaApiToken = null
+        this.tokenOrigin = null
+        this.tokenExpiry = null
+        this.country = 'US'
+
+        this.playlistPageLimit = 0
+        this.albumPageLimit = 0
+        this.playlistPageLoadConcurrency = BATCH_SIZE_DEFAULT
+        this.albumPageLoadConcurrency = BATCH_SIZE_DEFAULT
+
+        this.allowExplicit = true
+
+        this.tokenInitialized = false
+        this.settingUp = false
+    }
+
+
+    async setup() {
+        if (this.tokenInitialized && this._isTokenValid()) return true
+
+        if (this.settingUp) return true
+        this.settingUp = true
+
+        try {
+            const cfg = this.config.sources?.applemusic
+            if (!cfg) {
+                logger('error', 'AppleMusic', 'Missing config.sources.applemusic')
+                return false
+            }
+
+            this.mediaApiToken = cfg.mediaApiToken
+            this.country = cfg.market || 'US'
+
+            this.playlistPageLimit = cfg.playlistLoadLimit ?? 0
+            this.albumPageLimit = cfg.albumLoadLimit ?? 0
+            this.playlistPageLoadConcurrency = cfg.playlistPageLoadConcurrency ?? BATCH_SIZE_DEFAULT
+            this.albumPageLoadConcurrency = cfg.albumPageLoadConcurrency ?? BATCH_SIZE_DEFAULT
+            this.allowExplicit = cfg.allowExplicit ?? true
+
+            if (!this.mediaApiToken) {
+                logger('error', 'AppleMusic', 'mediaApiToken missing')
+                return false
+            }
+
+            this._parseToken(this.mediaApiToken)
+
+            if (this.tokenExpiry && !this._isTokenValid()) {
+                logger(
+                    'error',
+                    'AppleMusic',
+                    `Token expired (expiresAt: ${new Date(this.tokenExpiry).toISOString()}).`
+                );
+                this.tokenInitialized = false;
+                return false;
+            }
+
+            this.tokenInitialized = true;
+
+            logger(
+                'info',
+                'AppleMusic',
+                `Token initialized (origin: ${this.tokenOrigin || 'none'}, expiresAt: ${this.tokenExpiry ? new Date(this.tokenExpiry).toISOString() : 'none'
+                })`
+            );
+
+
+            return true
+        } catch (e) {
+            logger('error', 'AppleMusic', `setup() error: ${e.message}`)
+            return false
+        } finally {
+            this.settingUp = false
+        }
+    }
+
+    _isTokenValid() {
+        if (!this.tokenExpiry) return true
+        return Date.now() < (this.tokenExpiry - 10000)
+    }
+
+    _parseToken(token) {
+        try {
+            const parts = token.split('.')
+            if (parts.length < 2) return
+
+            const payloadB64 = parts[1].replace(/-/g, '+').replace(/_/g, '/')
+            const padded = payloadB64 + '='.repeat((4 - (payloadB64.length % 4)) % 4)
+            const json = JSON.parse(Buffer.from(padded, 'base64').toString('utf-8'))
+
+            this.tokenOrigin = json.root_https_origin || null
+            this.tokenExpiry = json.exp ? json.exp * 1000 : null
+        } catch {
+            this.tokenOrigin = null
+            this.tokenExpiry = null
+        }
+    }
+
+
+    async _apiRequest(path) {
+        if (!this.tokenInitialized || !this._isTokenValid()) {
+            const ok = await this.setup()
+            if (!ok) throw new Error('AppleMusic token unavailable')
+        }
+
+        const url = path.startsWith('http') ? path : `${API_BASE}${path}`
+        try {
+            const { body, statusCode } = await http1makeRequest(url, {
+                headers: {
+                    Authorization: `Bearer ${this.mediaApiToken}`,
+                    Accept: 'application/json',
+                    Origin: this.tokenOrigin ? `https://${this.tokenOrigin}` : undefined
+                }
+            })
+
+            if (statusCode === 401) {
+                this.tokenInitialized = false
+                await this.setup()
+                return this._apiRequest(path)
+            }
+
+            if (statusCode < 200 || statusCode >= 300) {
+                logger('error', 'AppleMusic', `API error ${statusCode} for ${url}`)
+                return null
+            }
+
+            return body
+        } catch (e) {
+            logger('error', 'AppleMusic', `apiRequest error: ${e.message}`)
+            return null
+        }
+    }
+
+
+    _buildTrack(item, artworkOverride = null) {
+        if (!item?.id) return null
+
+        const a = item.attributes || {}
+        const artwork = artworkOverride || this._parseArtwork(a.artwork)
+
+        const info = {
+            identifier: item.id,
+            isSeekable: true,
+            author: a.artistName || 'Unknown',
+            length: a.durationInMillis ?? 0,
+            isStream: false,
+            position: 0,
+            title: a.name || 'Unknown',
+            uri: a.url || '',
+            artworkUrl: artwork,
+            isrc: a.isrc || null,
+            sourceName: 'applemusic',
+            explicit: (a.contentRating === 'explicit')
+        }
+
+        return {
+            encoded: encodeTrack(info),
+            info,
+            pluginInfo: {}
+        }
+    }
+
+    _parseArtwork(art) {
+        if (!art?.url) return null
+        return art.url.replace('{w}', art.width).replace('{h}', art.height)
+    }
+
+
+    async search(query) {
+        try {
+            const limit = this.config.maxSearchResults || 10
+            const q = encodeURIComponent(query)
+            const data = await this._apiRequest(
+                `/catalog/${this.country}/search?term=${q}&limit=${limit}&types=songs&extend=artistUrl`
+            )
+
+            const songs = data?.results?.songs?.data || []
+            if (!songs.length) return { loadType: 'empty', data: {} }
+
+            const tracks = songs.map(x => this._buildTrack(x)).filter(Boolean)
+            return { loadType: 'search', data: tracks }
+        } catch (e) {
+            return { exception: { message: e.message, severity: 'fault' } }
+        }
+    }
+
+
+    async resolve(url) {
+        try {
+            const m = this.patterns[0].exec(url)
+            if (!m) return { loadType: 'empty', data: {} }
+
+            const type = m[1]
+            const id = m[2]
+            const altTrackId = m[3]
+
+            switch (type) {
+                case 'song':
+                    return await this._resolveTrack(id)
+
+                case 'album':
+                    return altTrackId ? await this._resolveTrack(altTrackId) : await this._resolveAlbum(id)
+
+                case 'playlist':
+                    return await this._resolvePlaylist(id)
+
+                case 'artist':
+                    return await this._resolveArtist(id)
+            }
+        } catch (e) {
+            return { exception: { message: e.message, severity: 'fault' } }
+        }
+    }
+
+    async _resolveTrack(id) {
+        const data = await this._apiRequest(`/catalog/${this.country}/songs/${id}?extend=artistUrl`)
+        if (!data?.data?.[0]) {
+            return { exception: { message: 'Track not found.', severity: 'common' } }
+        }
+
+        return { loadType: 'track', data: this._buildTrack(data.data[0]) }
+    }
+
+    async _resolveAlbum(id) {
+        const albumData = await this._apiRequest(`/catalog/${this.country}/albums/${id}?extend=artistUrl`)
+        if (!albumData?.data?.[0]) {
+            return { exception: { message: 'Album not found.', severity: 'common' } }
+        }
+
+        const album = albumData.data[0]
+        const baseTracks = album.relationships?.tracks?.data || []
+
+        const total = album.relationships?.tracks?.meta?.total || baseTracks.length
+        const extra = await this._paginate(`/catalog/${this.country}/albums/${id}/tracks`, total, this.albumPageLimit)
+
+        const all = [...baseTracks, ...extra]
+
+        const artwork = this._parseArtwork(album.attributes?.artwork)
+
+        const tracks = all.map(i => this._buildTrack(
+            { id: i.id, attributes: { ...i.attributes, artwork: album.attributes.artwork } },
+            artwork
+        )).filter(Boolean)
+
+        return {
+            loadType: 'playlist',
+            data: {
+                info: { name: album.attributes.name, selectedTrack: 0 },
+                tracks
+            }
+        }
+    }
+
+    async _resolvePlaylist(id) {
+        const p = await this._apiRequest(`/catalog/${this.country}/playlists/${id}`)
+        if (!p?.data?.[0]) {
+            return { exception: { message: 'Playlist not found.', severity: 'common' } }
+        }
+
+        const playlist = p.data[0]
+        const baseTracks = playlist.relationships?.tracks?.data || []
+
+        const total = playlist.relationships?.tracks?.meta?.total || baseTracks.length
+        const extra = await this._paginate(
+            `/catalog/${this.country}/playlists/${id}/tracks?extend=artistUrl`,
+            total,
+            this.playlistPageLimit
+        )
+
+        const all = [...baseTracks, ...extra]
+
+        const artwork = this._parseArtwork(playlist.attributes.artwork)
+
+        const tracks = all.map(i => this._buildTrack(i, artwork)).filter(Boolean)
+
+        return {
+            loadType: 'playlist',
+            data: {
+                info: { name: playlist.attributes.name, selectedTrack: 0 },
+                tracks
+            }
+        }
+    }
+
+    async _resolveArtist(id) {
+        const top = await this._apiRequest(`/catalog/${this.country}/artists/${id}/view/top-songs`)
+        if (!top?.data) {
+            return { exception: { message: 'Artist not found.', severity: 'common' } }
+        }
+
+        const artistInfo = await this._apiRequest(`/catalog/${this.country}/artists/${id}`)
+        const artist = artistInfo?.data?.[0]?.attributes?.name || 'Artist'
+        const artwork = this._parseArtwork(artistInfo?.data?.[0]?.attributes?.artwork)
+
+        const tracks = top.data.map(t => this._buildTrack(t, artwork)).filter(Boolean)
+
+        return {
+            loadType: 'playlist',
+            data: {
+                info: { name: `${artist}'s Top Tracks`, selectedTrack: 0 },
+                tracks
+            }
+        }
+    }
+
+    async _paginate(basePath, totalItems, maxPages) {
+        const results = []
+        const pages = Math.ceil(totalItems / MAX_PAGE_ITEMS)
+
+        let allowed = pages
+        if (maxPages > 0) allowed = Math.min(pages, maxPages)
+
+        for (let i = 1; i < allowed; i++) {
+            const offset = i * MAX_PAGE_ITEMS
+            const path =
+                `${basePath}${basePath.includes('?') ? '&' : '?'}limit=${MAX_PAGE_ITEMS}&offset=${offset}`
+
+            const page = await this._apiRequest(path)
+            if (page?.data) results.push(...page.data)
+        }
+
+        return results
+    }
+
+    async getTrackUrl(decodedTrack) {
+        const isExplicit = decodedTrack.explicit === true
+        const duration = decodedTrack.length
+
+        const query = this._buildSearchQuery(decodedTrack, isExplicit)
+
+        try {
+            const res = await this.nodelink.sources.searchWithDefault(query)
+            if (res.loadType !== 'search' || res.data.length === 0) {
+                return { exception: { message: 'No alternative found.', severity: 'fault' } }
+            }
+
+            const best = this._findBestMatch(res.data, duration, decodedTrack)
+            if (!best) {
+                return { exception: { message: 'No suitable match.', severity: 'fault' } }
+            }
+
+            const stream = await this.nodelink.sources.getTrackUrl(best.info)
+            return { newTrack: best, ...stream }
+        } catch (e) {
+            return { exception: { message: e.message, severity: 'fault' } }
+        }
+    }
+
+    _buildSearchQuery(track, isExplicit) {
+        let s = `${track.title} ${track.author}`
+        if (isExplicit) {
+            s += this.allowExplicit ? ' explicit lyrical video' : ' non explicit lyrical video'
+        }
+        return s
+    }
+
+    _findBestMatch(list, target, original) {
+        const allowed = target * DURATION_TOLERANCE
+        let best = null
+        let bestScore = Infinity
+
+        for (const item of list) {
+            const dur = item.info.length
+            const diff = Math.abs(dur - target)
+            if (diff > allowed) continue
+
+            const tSim = this._sim(this._norm(original.title), this._norm(item.info.title))
+            const aSim = this._sim(this._norm(original.author), this._norm(item.info.author))
+
+            const score = diff * 0.5 + (1 - tSim) * target * 0.3 + (1 - aSim) * target * 0.2
+            if (score < bestScore) {
+                bestScore = score
+                best = item
+            }
+        }
+
+        return best
+    }
+
+    _norm(t) {
+        if (!t) return ''
+        return t.toLowerCase().replace(/[^\w\s]/g, '').trim()
+    }
+
+    _sim(a, b) {
+        if (!a.length && !b.length) return 1
+        const l = a.length > b.length ? a : b
+        const s = a.length > b.length ? b : a
+        const dist = this._lev(a, b)
+        return (l.length - dist) / l.length
+    }
+
+    _lev(a, b) {
+        const m = []
+        for (let i = 0; i <= b.length; i++) m[i] = [i]
+        for (let j = 0; j <= a.length; j++) m[0][j] = j
+
+        for (let i = 1; i <= b.length; i++) {
+            for (let j = 1; j <= a.length; j++) {
+                m[i][j] =
+                    a[j - 1] === b[i - 1]
+                        ? m[i - 1][j - 1]
+                        : Math.min(m[i - 1][j - 1] + 1, m[i][j - 1] + 1, m[i - 1][j] + 1)
+            }
+        }
+
+        return m[b.length][a.length]
+    }
+}


### PR DESCRIPTION
## Changes

- Added a full AppleMusicSource implementation following the structure of the existing Spotify source.
- Implemented URL resolving for Apple Music songs, albums, playlists, and artists.
- Added search support using Apple’s `/v1/catalog/.../search` endpoint with proper metadata extraction.
- Integrated fallback mirroring using the default provider with duration and similarity scoring.
- Implemented token parsing with origin extraction, optional expiry handling, and proper validation.
- Added setup locking to prevent repeated initializations or token spam.
- Implemented Apple Music lyrics fetching and handling based on track identifiers.
- Added pagination for large albums and playlists (300 items per page).
- Improved artwork parsing for Apple’s `{w}` and `{h}` placeholders.
- Ensured track encoding/output stays fully compatible with Lavalink clients.

## Why

Apple Music support has been requested a lot, and adding it provides another major streaming platform that users rely on.  
This also includes native lyrics fetching for Apple Music, which improves the experience for music-related features that depend on accurate lyric data.  
Overall, this brings the Apple ecosystem up to par with the existing Spotify support and makes the source system more complete.

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional Information

If needed, I can share sample responses, test cases used during development, or help with adding an Apple Music token auto-scraper similar to the Java implementation.
