### PR TITLE
add: commitlint setup to enforce custom guidelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@
 !README.md
 !config.default.js 
 !biome.json
+!.husky
+!.husky/**
+!commitlint.config.mjs
+!.gitmessage

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,6 @@
+# <type>: <short description> (#PR merged)
+# Types: add | update | remove | fix | improve
+
+# Full description of the commit.
+
+# Co-authored-by: name <email> (optional)

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit \

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run prepare

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,35 @@
+// commitlint.config.js
+export default {
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+      // 1. Enforce your specific commit types
+      'type-enum': [
+        2,
+        'always',
+        [
+          'add',
+          'update',
+          'remove',
+          'fix',
+          'improve',
+        ]
+      ],
+      // 2. Enforce lowercase types (e.g., 'add' not 'Add')
+      'type-case': [2, 'always', 'lowercase'],
+      
+      // 3. Disable scopes (Your example is "type: desc", not "type(scope): desc")
+      'scope-empty': [2, 'always'],
+      
+      // 4. Ensure there is a subject (description)
+      'subject-empty': [2, 'never'],
+      
+      // 5. Ensure the subject does not end with a period
+      'subject-full-stop': [2, 'never', '.'],
+      
+      // 6. Max length of the header (72 is standard for git legibility)
+      'header-max-length': [2, 'always', 72],
+    },
+    ignores: [(commit) => commit === ""],
+
+    defaultIgnores: true,
+  };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.7",
-    "dotenv": "^17.2.3"
+    "@commitlint/cli": "20.1.0",
+    "@commitlint/config-conventional": "20.0.0",
+    "dotenv": "^17.2.3",
+    "husky": "9.1.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "prebuild": "node scripts/prebuild.js",
     "start": "node --dns-result-order=ipv4first --openssl-legacy-provider src/index.js",
-    "start:bun": "bun run --dns-result-order=ipv4first src/index.js"
+    "start:bun": "bun run --dns-result-order=ipv4first src/index.js",
+    "prepare": "husky"
   },
   "type": "module",
   "main": "src/index.js",


### PR DESCRIPTION
This commit adds commitlint and husky with version locks (to prevent auto-updates), and a commitlint config file that attempts to Follow ORG's Commit Rules present at: https://github.com/PerformanC/contributing/blob/82f2a9b06d41044cabea416a4c30dbf818f1d136/README.md