### PR TITLE
improve: replace streamprocessor packages with a rust implementation for performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,16 +15,13 @@
     "@ecliptia/seekable-stream": "github:1Lucas1apk/seekable-stream",
     "@performanc/pwsl-server": "github:performanc/internals#PWSL-server",
     "@performanc/voice": "github:PerformanC/voice",
-    "@wasm-audio-decoders/flac": "^0.2.10",
-    "@wasm-audio-decoders/ogg-vorbis": "^0.1.20",
+    "@toddynnn/symphonia-decoder": "1.0.3",
     "mp4box": "^2.3.0",
-    "mpg123-decoder": "^1.0.3",
     "myzod": "^1.12.1",
-    "sodium-native": "^5.0.10",
     "toddy-mediaplex": "^2.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.7",
+    "@biomejs/biome": "^2.3.8",
     "@commitlint/cli": "20.1.0",
     "@commitlint/config-conventional": "20.0.0",
     "dotenv": "^17.2.3",

--- a/src/playback/streamProcessor.js
+++ b/src/playback/streamProcessor.js
@@ -1,58 +1,185 @@
 import { Buffer } from 'node:buffer'
-import { createRequire } from 'node:module'
 import { PassThrough, Readable, Transform } from 'node:stream'
+
 import LibSampleRate from '@alexanderolsen/libsamplerate-js'
 import FAAD2NodeDecoder from '@ecliptia/faad2-wasm/faad2_node_decoder.js'
 import { SeekError, seekableStream } from '@ecliptia/seekable-stream'
-import { FLACDecoder } from '@wasm-audio-decoders/flac'
-import { OggVorbisDecoder } from '@wasm-audio-decoders/ogg-vorbis'
 import * as MP4Box from 'mp4box'
-import { MPEGDecoder } from 'mpg123-decoder'
 
 import { normalizeFormat, SupportedFormats } from '../constants.js'
 import WebmOpusDemuxer from './demuxers/WebmOpus.js'
 import { FiltersManager } from './filtersManager.js'
 import { Decoder as OpusDecoder, Encoder as OpusEncoder } from './opus/Opus.js'
 import { VolumeTransformer } from './VolumeTransformer.js'
+import { SymphoniaDecoder } from '@toddynnn/symphonia-decoder'
+
+const AUDIO_CONFIG = Object.freeze({
+  sampleRate: 48000,
+  channels: 2,
+  frameSize: 960,
+  highWaterMark: 19200
+})
+
+const BUFFER_THRESHOLDS = Object.freeze({
+  maxCompressed: 256 * 1024,
+  minCompressed: 128 * 1024
+})
+
+const AUDIO_CONSTANTS = Object.freeze({
+  pcmFloatFactor: 32767,
+  maxDecodesPerTick: 5,
+  decodeIntervalMs: 10
+})
+
+const MPEGTS_CONFIG = Object.freeze({
+  syncByte: 0x47,
+  packetSize: 188,
+  aacStreamType: 0x0f
+})
+
+const DOWNMIX_COEFFICIENTS = Object.freeze({
+  center: 0.7071,
+  surround: 0.7071,
+  lfe: 0.5
+})
+
+const SAMPLE_RATES = Object.freeze([
+  96000, 88200, 64000, 48000, 44100, 32000,
+  24000, 22050, 16000, 12000, 11025, 8000, 7350
+])
+
+const EMPTY_BUFFER = Buffer.alloc(0)
 
 const _getResamplerConverterType = (quality) => {
-  switch (quality) {
-    case 'best':
-      return LibSampleRate.ConverterType.SRC_SINC_BEST_QUALITY
-    case 'medium':
-      return LibSampleRate.ConverterType.SRC_SINC_MEDIUM_QUALITY
-    case 'fastest':
-      return LibSampleRate.ConverterType.SRC_SINC_FASTEST
-    case 'zero order holder':
-      return LibSampleRate.ConverterType.SRC_ZERO_ORDER_HOLD
-    case 'linear':
-      return LibSampleRate.ConverterType.SRC_LINEAR
-    default:
-      return LibSampleRate.ConverterType.SRC_SINC_FASTEST
+  const types = LibSampleRate.ConverterType
+  const qualityMap = {
+    best: types.SRC_SINC_BEST_QUALITY,
+    medium: types.SRC_SINC_MEDIUM_QUALITY,
+    fastest: types.SRC_SINC_FASTEST,
+    'zero order holder': types.SRC_ZERO_ORDER_HOLD,
+    linear: types.SRC_LINEAR
   }
+  return qualityMap[quality] || types.SRC_SINC_FASTEST
 }
+
+const _clampSample = (value) => {
+  if (value > 1) return 1
+  if (value < -1) return -1
+  return value
+}
+
+const _floatToInt16Buffer = (floatArray) => {
+  const length = floatArray.length
+  const output = new Int16Array(length)
+
+  for (let i = 0; i < length; i++) {
+    output[i] = _clampSample(floatArray[i]) * AUDIO_CONSTANTS.pcmFloatFactor
+  }
+
+  return Buffer.from(output.buffer)
+}
+
+const _createAdtsHeader = (sampleLength, profile, samplingIndex, channelCount) => {
+  const frameLength = sampleLength + 7
+  const profileIndex = profile - 1
+
+  return Buffer.from([
+    0xff,
+    0xf1,
+    ((profileIndex & 0x03) << 6) | ((samplingIndex & 0x0f) << 2) | ((channelCount & 0x04) >> 2),
+    ((channelCount & 0x03) << 6) | ((frameLength & 0x1800) >> 11),
+    (frameLength & 0x7f8) >> 3,
+    ((frameLength & 0x7) << 5) | 0x1f,
+    0xfc
+  ])
+}
+
+const _parseBoxes = (buffer, offset = 0) => {
+  const boxes = []
+  const bufferLength = buffer.length
+
+  while (offset + 8 <= bufferLength) {
+    const size = buffer.readUInt32BE(offset)
+    const type = buffer.toString('ascii', offset + 4, offset + 8)
+
+    if (size === 0 || size > bufferLength - offset) break
+    if (type === '\0\0\0\0') break
+
+    boxes.push({
+      type,
+      size,
+      data: buffer.subarray(offset + 8, offset + size),
+      offset
+    })
+
+    offset += size
+  }
+
+  return boxes
+}
+
+const _findNestedBox = (boxes, ...path) => {
+  let current = boxes
+
+  for (const boxType of path) {
+    const box = current.find((b) => b.type === boxType)
+    if (!box) return null
+    current = _parseBoxes(box.data)
+  }
+
+  return current
+}
+
+const _createErrorResponse = (message, cause = 'UNKNOWN') => ({
+  exception: {
+    message,
+    severity: 'fault',
+    cause
+  }
+})
+
+const _isFmp4Format = (type) =>
+  type.indexOf('fmp4') !== -1 ||
+  type.indexOf('hls') !== -1 ||
+  type.indexOf('mpegurl') !== -1
+
+const _isMpegtsFormat = (type) =>
+  type.indexOf('mpegts') !== -1 ||
+  type.indexOf('video/mp2t') !== -1
+
+const _isMp4Format = (type) =>
+  type.indexOf('mp4') !== -1 ||
+  type.indexOf('m4a') !== -1 ||
+  type.indexOf('m4v') !== -1 ||
+  type.indexOf('mov') !== -1
+
+const _isWebmFormat = (type) =>
+  type.indexOf('webm') !== -1
 
 class BaseAudioResource {
   constructor() {
     this.pipes = []
     this.stream = null
+    this._destroyed = false
   }
 
   _end() {
-    if (!this.pipes) return
+    if (this._destroyed || !this.pipes) return
+    this._destroyed = true
 
-    if (this.pipes[0]?.stopHls) {
-      this.pipes[0].stopHls()
+    const firstPipe = this.pipes[0]
+
+    if (firstPipe?.stopHls) {
+      firstPipe.stopHls()
     }
 
-    if (
-      this.pipes[0]?.responseStream &&
-      !this.pipes[0].responseStream.destroyed
-    ) {
-      this.pipes[0].responseStream.destroy()
+    if (firstPipe?.responseStream?.destroyed === false) {
+      firstPipe.responseStream.destroy()
     }
 
-    for (const pipe of this.pipes) {
+    for (let i = this.pipes.length - 1; i >= 0; i--) {
+      const pipe = this.pipes[i]
+      pipe.abort?.()
       pipe.unpipe?.()
       pipe.destroy?.()
       pipe.removeAllListeners?.()
@@ -69,9 +196,7 @@ class BaseAudioResource {
   setVolume(volume) {
     if (!this.pipes) return
 
-    const volumeTransformer = this.pipes.find(
-      (pipe) => pipe instanceof VolumeTransformer
-    )
+    const volumeTransformer = this.pipes.find((p) => p instanceof VolumeTransformer)
 
     if (volumeTransformer) {
       volumeTransformer.setVolume(volume)
@@ -83,649 +208,543 @@ class BaseAudioResource {
   setFilters(filters) {
     if (!this.pipes) return
 
-    const filterTransformer = this.pipes.find(
-      (pipe) => pipe instanceof FiltersManager
-    )
+    const filterManager = this.pipes.find((p) => p instanceof FiltersManager)
 
-    if (filterTransformer) {
-      filterTransformer.update(filters)
+    if (filterManager) {
+      filterManager.update(filters)
     } else {
       throw new Error('Filters not found in the pipeline.')
     }
   }
 
-  emit(event, ...args) {
-    this.stream?.emit(event, ...args)
-  }
-
-  on(event, listener) {
-    this.stream?.on(event, listener)
-  }
-
-  off(event, listener) {
-    this.stream?.off(event, listener)
-  }
-
-  once(event, listener) {
-    this.stream?.once(event, listener)
-  }
-
-  removeListener(event, listener) {
-    this.stream?.removeListener(event, listener)
-  }
+  emit(event, ...args) { this.stream?.emit(event, ...args) }
+  on(event, listener) { this.stream?.on(event, listener) }
+  off(event, listener) { this.stream?.off(event, listener) }
+  once(event, listener) { this.stream?.once(event, listener) }
+  removeListener(event, listener) { this.stream?.removeListener(event, listener) }
 
   removeAllListeners() {
     if (!this.stream?.eventNames) return
 
     for (const eventName of this.stream.eventNames()) {
-      for (const listener of this.stream.listeners(eventName)) {
-        this.stream.removeListener(eventName, listener)
-      }
+      this.stream.removeAllListeners(eventName)
     }
   }
 
-  read() {
-    return this.stream?.read()
-  }
-
-  resume() {
-    this.stream?.resume()
-  }
+  read() { return this.stream?.read() }
+  resume() { this.stream?.resume() }
 }
 
-class MpegDecoderStream extends Transform {
-  constructor(options) {
-    super(options)
-    this.decoder = new MPEGDecoder()
-    this.resampler = null
-    this.isDecoderReady = false
-    this.resamplingQuality = options?.resamplingQuality || 'fastest'
+class SymphoniaDecoderStream extends Transform {
+  constructor(options = {}) {
+    super({
+      ...options,
+      highWaterMark: AUDIO_CONFIG.highWaterMark,
+      objectMode: false
+    })
 
-    this.decoder.ready
-      .then(() => {
-        this.isDecoderReady = true
-        this.emit('decoderReady')
-      })
-      .catch((err) => this.emit('error', err))
+    this.decoder = new SymphoniaDecoder()
+    this.resampler = null
+    this.resamplingQuality = options.resamplingQuality || 'fastest'
+    this.resumeInput = null
+    this.isFinished = false
+    this._aborted = false
+    this._loopScheduled = false
+    this._isDecoding = false
+    this._timeoutId = null
+    this._immediateId = null
+
+    this.on('resume', () => {
+      if (!this.isFinished && !this._aborted && this.decoder) {
+        this._scheduleDecode()
+      }
+    })
+  }
+
+  abort() {
+    this._aborted = true
+    this._cancelTimers()
+  }
+
+  _cancelTimers() {
+    if (this._timeoutId) {
+      clearTimeout(this._timeoutId)
+      this._timeoutId = null
+    }
+    if (this._immediateId) {
+      clearImmediate(this._immediateId)
+      this._immediateId = null
+    }
+    this._loopScheduled = false
+  }
+
+  _isDecoderValid() {
+    return this.decoder !== null && !this._aborted && !this.isFinished
   }
 
   _transform(chunk, encoding, callback) {
-    if (!this.isDecoderReady) {
-      this.once('decoderReady', () =>
-        this._transform(chunk, encoding, callback)
-      )
+    if (this._aborted || !this.decoder) {
+      callback()
       return
     }
 
-    try {
-      const { channelData, samplesDecoded, sampleRate, channels } =
-        this.decoder.decode(chunk)
+    this.decoder.push(chunk)
+    this._scheduleDecode()
 
-      if (samplesDecoded > 0) {
-        if (sampleRate === 48000) {
-          this._process(channelData, channels, callback)
-        } else if (this.resampler) {
-          this._resample(channelData, channels, callback)
-        } else {
-          LibSampleRate.create(2, sampleRate, 48000, {
-            converterType: _getResamplerConverterType(this.resamplingQuality)
+    const bufferedBytes = this.decoder?.bufferedBytes ?? 0
+    if (bufferedBytes > BUFFER_THRESHOLDS.maxCompressed) {
+      this.resumeInput = callback
+    } else {
+      callback()
+    }
+  }
+
+  _scheduleDecode() {
+    if (this._loopScheduled || this._isDecoding || !this._isDecoderValid()) return
+
+    this._loopScheduled = true
+
+    this._timeoutId = setTimeout(() => {
+      this._timeoutId = null
+      this._loopScheduled = false
+      if (this._isDecoderValid()) {
+        this._decodeLoop()
+      }
+    }, AUDIO_CONSTANTS.decodeIntervalMs)
+  }
+
+  async _decodeLoop() {
+    if (!this._isDecoderValid() || this.readableFlowing === false) return
+
+    this._isDecoding = true
+
+    try {
+      let hasMoreData = true
+
+      while (hasMoreData && this._isDecoderValid() && this.readableFlowing !== false) {
+        hasMoreData = await this._processAudio()
+
+        if (hasMoreData && this._isDecoderValid()) {
+          await new Promise((resolve) => {
+            this._immediateId = setImmediate(() => {
+              this._immediateId = null
+              resolve()
+            })
           })
-            .then((src) => {
-              this.resampler = src
-              this._resample(channelData, channels, callback)
-            })
-            .catch(() => {
-              callback()
-            })
         }
-      } else {
+      }
+    } catch (err) {
+      if (!this._aborted) this.emit('error', err)
+    } finally {
+      this._isDecoding = false
+    }
+
+    const bufferedBytes = this.decoder?.bufferedBytes ?? 0
+    if (bufferedBytes > 0 && this._isDecoderValid()) {
+      this._scheduleDecode()
+    }
+  }
+
+  async _processAudio() {
+    if (!this._isDecoderValid()) return false
+
+    if (!this.decoder.isProbed) {
+      try {
+        if (!this.decoder.initialize()) return false
+      } catch (err) {
+        throw new Error(`Symphonia init failed: ${err.message}`)
+      }
+    }
+
+    let decodeCount = 0
+    let hasOutput = false
+
+    while (decodeCount < AUDIO_CONSTANTS.maxDecodesPerTick && this._isDecoderValid()) {
+      const bufferedBytes = this.decoder?.bufferedBytes ?? 0
+      const result = this.decoder?.decode()
+
+      if (!result) break
+
+      const { samples, sampleRate, channels } = result
+
+      const output = sampleRate !== AUDIO_CONFIG.sampleRate
+        ? await this._resample(samples, channels, sampleRate)
+        : samples
+
+      if (this._aborted) break
+
+      const canPush = this.push(output)
+      hasOutput = true
+      decodeCount++
+
+      if (this.resumeInput && bufferedBytes < BUFFER_THRESHOLDS.minCompressed) {
+        const callback = this.resumeInput
+        this.resumeInput = null
         callback()
       }
-    } catch (e) {
-      callback(e)
+
+      if (!canPush) break
     }
+
+    const remainingBytes = this.decoder?.bufferedBytes ?? 0
+    return hasOutput || remainingBytes > 0
   }
 
-  _process(channelData, channels, callback) {
-    const sampleCount = channelData[0].length
-    const pcm = new Int16Array(sampleCount * 2)
-    const floatL = channelData[0]
-    const floatR = channels > 1 ? channelData[1] : floatL
+  async _resample(pcmInt16, channels, inputRate) {
+    if (this._aborted) return EMPTY_BUFFER
 
-    for (let i = 0; i < sampleCount; i++) {
-      pcm[i * 2] = Math.max(-1, Math.min(1, floatL[i])) * 32767
-      pcm[i * 2 + 1] = Math.max(-1, Math.min(1, floatR[i])) * 32767
+    if (!this.resampler) {
+      this.resampler = await LibSampleRate.create(
+        channels,
+        inputRate,
+        AUDIO_CONFIG.sampleRate,
+        { converterType: _getResamplerConverterType(this.resamplingQuality) }
+      )
     }
 
-    this.push(Buffer.from(pcm.buffer))
-    callback()
-  }
+    const float32 = new Float32Array(
+      pcmInt16.buffer,
+      pcmInt16.byteOffset,
+      pcmInt16.length / 2
+    )
 
-  _resample(channelData, channels, callback) {
-    const floatL = channelData[0]
-    const floatR = channels > 1 ? channelData[1] : floatL
-    const interleaved = new Float32Array(floatL.length * 2)
-
-    for (let i = 0; i < floatL.length; i++) {
-      interleaved[i * 2] = floatL[i]
-      interleaved[i * 2 + 1] = floatR[i]
-    }
-
-    const resampled = this.resampler.full(interleaved)
-    const pcmInt16 = new Int16Array(resampled.length)
-
-    for (let i = 0; i < resampled.length; i++) {
-      pcmInt16[i] = Math.max(-1, Math.min(1, resampled[i])) * 32767
-    }
-
-    this.push(Buffer.from(pcmInt16.buffer))
-    callback()
+    return _floatToInt16Buffer(this.resampler.full(float32))
   }
 
   _flush(callback) {
-    if (this.resampler) {
-      this.resampler.destroy()
+    this.isFinished = true
+    this._cancelTimers()
+
+    if (this._aborted || !this.decoder) {
+      this._cleanup()
+      callback()
+      return
     }
+
+    try {
+      this.decoder.closeInput()
+
+      let result
+      let count = 0
+      while ((result = this.decoder?.decode()) !== null && result && count < 10) {
+        this.push(result.samples)
+        count++
+      }
+    } catch {}
+
+    this._cleanup()
+    callback()
+  }
+
+  _destroy(err, callback) {
+    this._aborted = true
+    this.isFinished = true
+    this._cancelTimers()
+
+    if (this.resumeInput) {
+      const cb = this.resumeInput
+      this.resumeInput = null
+      cb()
+    }
+
+    this._cleanup()
+    super._destroy(err, callback)
+  }
+
+  _cleanup() {
+    this._cancelTimers()
+
     if (this.decoder) {
-      this.decoder.free()
-    }
-    callback()
-  }
-}
-
-class FLACDecoderStream extends Transform {
-  constructor(options) {
-    super(options)
-    this.decoder = new FLACDecoder()
-    this.resampler = null
-    this.isDecoderReady = false
-    this.resamplingQuality = options?.resamplingQuality || 'fastest'
-
-    this.decoder.ready
-      .then(() => {
-        this.isDecoderReady = true
-        this.emit('decoderReady')
-      })
-      .catch((err) => this.emit('error', err))
-  }
-
-  async _transform(chunk, encoding, callback) {
-    if (!this.isDecoderReady) {
-      this.once('decoderReady', () =>
-        this._transform(chunk, encoding, callback)
-      )
-      return
+      try {
+        this.decoder.flush()
+      } catch {}
+      try {
+        this.decoder.free()
+      } catch {}
+      this.decoder = null
     }
 
-    try {
-      const result = await this.decoder.decode(chunk)
-
-      if (result && result.samplesDecoded > 0) {
-        const { channelData, samplesDecoded, sampleRate } = result
-        const channels = channelData.length
-
-        if (sampleRate === 48000) {
-          this._process(channelData, channels, samplesDecoded, callback)
-        } else if (this.resampler) {
-          this._resample(
-            channelData,
-            channels,
-            samplesDecoded,
-            sampleRate,
-            callback
-          )
-        } else {
-          try {
-            this.resampler = await LibSampleRate.create(2, sampleRate, 48000, {
-              converterType: _getResamplerConverterType(this.resamplingQuality)
-            })
-            this._resample(
-              channelData,
-              channels,
-              samplesDecoded,
-              sampleRate,
-              callback
-            )
-          } catch (err) {
-            callback()
-          }
-        }
-      } else {
-        callback()
-      }
-    } catch (e) {
-      callback()
+    if (this.resampler) {
+      try {
+        this.resampler.destroy()
+      } catch {}
+      this.resampler = null
     }
-  }
-
-  _process(channelData, channels, samplesDecoded, callback) {
-    const pcm = new Int16Array(samplesDecoded * 2)
-    const floatL = channelData[0]
-    const floatR = channels > 1 ? channelData[1] : floatL
-
-    for (let i = 0; i < samplesDecoded; i++) {
-      pcm[i * 2] = Math.max(-1, Math.min(1, floatL[i])) * 32767
-      pcm[i * 2 + 1] = Math.max(-1, Math.min(1, floatR[i])) * 32767
-    }
-
-    this.push(Buffer.from(pcm.buffer))
-    callback()
-  }
-
-  _resample(channelData, channels, samplesDecoded, sampleRate, callback) {
-    const floatL = channelData[0]
-    const floatR = channels > 1 ? channelData[1] : floatL
-    const interleaved = new Float32Array(samplesDecoded * 2)
-
-    for (let i = 0; i < samplesDecoded; i++) {
-      interleaved[i * 2] = floatL[i]
-      interleaved[i * 2 + 1] = floatR[i]
-    }
-
-    const resampled = this.resampler.full(interleaved)
-    const pcmInt16 = new Int16Array(resampled.length)
-
-    for (let i = 0; i < resampled.length; i++) {
-      pcmInt16[i] = Math.max(-1, Math.min(1, resampled[i])) * 32767
-    }
-
-    this.push(Buffer.from(pcmInt16.buffer))
-    callback()
-  }
-
-  async _flush(callback) {
-    try {
-      const result = await this.decoder.flush()
-      if (result && result.samplesDecoded > 0) {
-        const { channelData, samplesDecoded, sampleRate } = result
-        const channels = channelData.length
-
-        if (sampleRate === 48000) {
-          this._process(channelData, channels, samplesDecoded, () => {})
-        } else if (this.resampler) {
-          this._resample(
-            channelData,
-            channels,
-            samplesDecoded,
-            sampleRate,
-            () => {}
-          )
-        }
-      }
-    } catch (err) {}
-
-    if (this.resampler) this.resampler.destroy?.()
-    if (this.decoder) this.decoder.free?.()
-    callback()
-  }
-}
-
-class OggVorbisDecoderStream extends Transform {
-  constructor(options) {
-    super(options)
-    this.decoder = new OggVorbisDecoder()
-    this.resampler = null
-    this.isDecoderReady = false
-    this.resamplingQuality = options?.resamplingQuality || 'fastest'
-
-    this.decoder.ready
-      .then(() => {
-        this.isDecoderReady = true
-        this.emit('decoderReady')
-      })
-      .catch((err) => this.emit('error', err))
-  }
-
-  async _transform(chunk, encoding, callback) {
-    if (!this.isDecoderReady) {
-      this.once('decoderReady', () =>
-        this._transform(chunk, encoding, callback)
-      )
-      return
-    }
-
-    try {
-      const result = await this.decoder.decode(chunk)
-
-      if (result && result.samplesDecoded > 0) {
-        const { channelData, samplesDecoded, sampleRate } = result
-        const channels = channelData.length
-
-        if (sampleRate === 48000) {
-          this._process(channelData, channels, samplesDecoded, callback)
-        } else if (this.resampler) {
-          this._resample(
-            channelData,
-            channels,
-            samplesDecoded,
-            sampleRate,
-            callback
-          )
-        } else {
-          try {
-            this.resampler = await LibSampleRate.create(2, sampleRate, 48000, {
-              converterType: _getResamplerConverterType(this.resamplingQuality)
-            })
-            this._resample(
-              channelData,
-              channels,
-              samplesDecoded,
-              sampleRate,
-              callback
-            )
-          } catch (err) {
-            callback()
-          }
-        }
-      } else {
-        callback()
-      }
-    } catch (e) {
-      callback()
-    }
-  }
-
-  _process(channelData, channels, samplesDecoded, callback) {
-    const pcm = new Int16Array(samplesDecoded * 2)
-    const floatL = channelData[0]
-    const floatR = channels > 1 ? channelData[1] : floatL
-
-    for (let i = 0; i < samplesDecoded; i++) {
-      pcm[i * 2] = Math.max(-1, Math.min(1, floatL[i])) * 32767
-      pcm[i * 2 + 1] = Math.max(-1, Math.min(1, floatR[i])) * 32767
-    }
-
-    this.push(Buffer.from(pcm.buffer))
-    callback()
-  }
-
-  _resample(channelData, channels, samplesDecoded, sampleRate, callback) {
-    const floatL = channelData[0]
-    const floatR = channels > 1 ? channelData[1] : floatL
-    const interleaved = new Float32Array(samplesDecoded * 2)
-
-    for (let i = 0; i < samplesDecoded; i++) {
-      interleaved[i * 2] = floatL[i]
-      interleaved[i * 2 + 1] = floatR[i]
-    }
-
-    const resampled = this.resampler.full(interleaved)
-    const pcmInt16 = new Int16Array(resampled.length)
-
-    for (let i = 0; i < resampled.length; i++) {
-      pcmInt16[i] = Math.max(-1, Math.min(1, resampled[i])) * 32767
-    }
-
-    this.push(Buffer.from(pcmInt16.buffer))
-    callback()
-  }
-
-  async _flush(callback) {
-    try {
-      const result = await this.decoder.flush()
-      if (result && result.samplesDecoded > 0) {
-        const { channelData, samplesDecoded, sampleRate } = result
-        const channels = channelData.length
-
-        if (sampleRate === 48000) {
-          this._process(channelData, channels, samplesDecoded, () => {})
-        } else if (this.resampler) {
-          this._resample(
-            channelData,
-            channels,
-            samplesDecoded,
-            sampleRate,
-            () => {}
-          )
-        }
-      }
-    } catch (err) {}
-
-    if (this.resampler) this.resampler.destroy?.()
-    if (this.decoder) this.decoder.free?.()
-    callback()
   }
 }
 
 class MPEGTSToAACStream extends Transform {
   constructor(options) {
-    super(options)
-    this.buffer = Buffer.alloc(0)
+    super({
+      ...options,
+      highWaterMark: AUDIO_CONFIG.highWaterMark
+    })
+
+    this.buffer = EMPTY_BUFFER
     this.patPmtId = null
     this.aacPid = null
-    this.aacData = Buffer.alloc(0)
-    this.packetsProcessed = 0
+    this.aacData = EMPTY_BUFFER
     this.aacPidFound = false
+    this._aborted = false
+  }
+
+  abort() {
+    this._aborted = true
+    this.buffer = EMPTY_BUFFER
+    this.aacData = EMPTY_BUFFER
   }
 
   _transform(chunk, encoding, callback) {
+    if (this._aborted) {
+      callback()
+      return
+    }
+
     try {
-      let dataToProcess = chunk
-      if (this.buffer.length > 0) {
-        dataToProcess = Buffer.concat([this.buffer, chunk])
-        this.buffer = Buffer.alloc(0)
-      }
+      const data = this.buffer.length > 0
+        ? Buffer.concat([this.buffer, chunk])
+        : chunk
 
-      const len = dataToProcess.length
-      let pos = 0
+      this.buffer = EMPTY_BUFFER
 
-      while (pos <= len - 188) {
-        if (dataToProcess[pos] !== 0x47) {
-          const syncIndex = dataToProcess.indexOf(0x47, pos + 1)
+      const dataLength = data.length
+      let position = 0
+
+      while (position <= dataLength - MPEGTS_CONFIG.packetSize && !this._aborted) {
+        if (data[position] !== MPEGTS_CONFIG.syncByte) {
+          const syncIndex = data.indexOf(MPEGTS_CONFIG.syncByte, position + 1)
           if (syncIndex === -1) {
-            pos = len
+            position = dataLength
             break
           }
-          pos = syncIndex
+          position = syncIndex
           continue
         }
 
-        const packet = dataToProcess.subarray(pos, pos + 188)
-        this.packetsProcessed++
+        const packet = data.subarray(position, position + MPEGTS_CONFIG.packetSize)
 
-        const pusi = !!(packet[1] & 0x40)
+        const payloadUnitStartIndicator = !!(packet[1] & 0x40)
         const pid = ((packet[1] & 0x1f) << 8) + packet[2]
-        const atf = (packet[3] & 0x30) >> 4
+        const adaptationFieldControl = (packet[3] & 0x30) >> 4
 
         let offset = 4
-        if (atf > 1) {
-          const atflen = packet[4]
-          offset = 5 + atflen
-          if (offset >= 188) {
-            pos += 188
+        if (adaptationFieldControl > 1) {
+          offset = 5 + packet[4]
+          if (offset >= MPEGTS_CONFIG.packetSize) {
+            position += MPEGTS_CONFIG.packetSize
             continue
           }
         }
 
-        if (pid === 0 && pusi) {
-          offset += packet[offset] + 1
-          this.patPmtId =
-            ((packet[offset + 10] & 0x1f) << 8) | packet[offset + 11]
-        } else if (this.patPmtId && pid === this.patPmtId && pusi) {
-          offset += packet[offset] + 1
-          const foundPid = this._parsePMT(packet, offset)
-          if (foundPid && !this.aacPidFound) {
-            this.aacPid = foundPid
-            this.aacPidFound = true
-          }
-        } else if (this.aacPid && pid === this.aacPid) {
-          if (pusi) {
-            if (this.aacData.length > 0) {
-              this.push(this.aacData)
-              this.aacData = Buffer.alloc(0)
-            }
-            const pesHeaderLength = packet[offset + 8]
-            offset += 9 + pesHeaderLength
-            if (offset >= 188) {
-              pos += 188
-              continue
-            }
-          }
-          const payload = packet.subarray(offset)
-          this.aacData = Buffer.concat([this.aacData, payload])
-        }
+        this._processPacket(packet, pid, payloadUnitStartIndicator, offset)
 
-        pos += 188
+        position += MPEGTS_CONFIG.packetSize
       }
 
-      if (pos < len) {
-        this.buffer = dataToProcess.subarray(pos)
+      if (position < dataLength && !this._aborted) {
+        this.buffer = data.subarray(position)
       }
+
       callback()
-    } catch (err) {
+    } catch {
       callback()
     }
   }
 
-  _parsePMT(packet, offset) {
-    const sectionLength =
-      ((packet[offset + 1] & 0x0f) << 8) | packet[offset + 2]
+  _processPacket(packet, pid, pusi, offset) {
+    if (pid === 0 && pusi) {
+      this._processPAT(packet, offset)
+    } else if (this.patPmtId && pid === this.patPmtId && pusi) {
+      this._processPMT(packet, offset)
+    } else if (this.aacPid && pid === this.aacPid) {
+      this._processAACPacket(packet, pusi, offset)
+    }
+  }
+
+  _processPAT(packet, offset) {
+    offset += packet[offset] + 1
+    this.patPmtId = ((packet[offset + 10] & 0x1f) << 8) | packet[offset + 11]
+  }
+
+  _processPMT(packet, offset) {
+    offset += packet[offset] + 1
+
+    const sectionLength = ((packet[offset + 1] & 0x0f) << 8) | packet[offset + 2]
     const tableEnd = offset + 3 + sectionLength - 4
-    const programInfoLength =
-      ((packet[offset + 10] & 0x0f) << 8) | packet[offset + 11]
+    const programInfoLength = ((packet[offset + 10] & 0x0f) << 8) | packet[offset + 11]
+
     offset += 12 + programInfoLength
 
-    while (offset < tableEnd && offset < 188) {
+    while (offset < tableEnd && offset < MPEGTS_CONFIG.packetSize) {
       const streamType = packet[offset]
-      const elementaryPid =
-        ((packet[offset + 1] & 0x1f) << 8) | packet[offset + 2]
-      const esInfoLength =
-        ((packet[offset + 3] & 0x0f) << 8) | packet[offset + 4]
+      const elementaryPid = ((packet[offset + 1] & 0x1f) << 8) | packet[offset + 2]
+      const esInfoLength = ((packet[offset + 3] & 0x0f) << 8) | packet[offset + 4]
 
-      if (streamType === 0x0f) {
-        return elementaryPid
+      if (streamType === MPEGTS_CONFIG.aacStreamType && !this.aacPidFound) {
+        this.aacPid = elementaryPid
+        this.aacPidFound = true
+        return
       }
+
       offset += 5 + esInfoLength
     }
-    return null
+  }
+
+  _processAACPacket(packet, pusi, offset) {
+    if (pusi) {
+      if (this.aacData.length > 0 && !this._aborted) {
+        this.push(this.aacData)
+        this.aacData = EMPTY_BUFFER
+      }
+
+      const pesHeaderLength = packet[offset + 8]
+      offset += 9 + pesHeaderLength
+
+      if (offset >= MPEGTS_CONFIG.packetSize) return
+    }
+
+    if (!this._aborted) {
+      this.aacData = Buffer.concat([this.aacData, packet.subarray(offset)])
+    }
   }
 
   _flush(callback) {
-    if (this.aacData.length > 0) {
+    if (this.aacData.length > 0 && !this._aborted) {
       this.push(this.aacData)
     }
+    this.aacData = EMPTY_BUFFER
+    this.buffer = EMPTY_BUFFER
     callback()
+  }
+
+  _destroy(err, callback) {
+    this._aborted = true
+    this.buffer = EMPTY_BUFFER
+    this.aacData = EMPTY_BUFFER
+    super._destroy(err, callback)
   }
 }
 
 class AACDecoderStream extends Transform {
   constructor(options) {
-    super(options)
+    super({
+      ...options,
+      highWaterMark: AUDIO_CONFIG.highWaterMark
+    })
+
     this.decoder = new FAAD2NodeDecoder()
     this.resampler = null
+    this.resamplerCreationPromise = null
+    this.resamplingQuality = options?.resamplingQuality || 'fastest'
+
     this.isDecoderReady = false
     this.isConfigured = false
     this.pendingChunks = []
-    this.buffer = Buffer.alloc(0)
-    this.resamplingQuality = options?.resamplingQuality || 'fastest'
-    this.resamplerCreationPromise = null
+    this.buffer = EMPTY_BUFFER
+    this._aborted = false
 
     this.decoder.ready
       .then(() => {
+        if (this._aborted) return
         this.isDecoderReady = true
         this.emit('decoderReady')
         this._processPendingChunks()
       })
-      .catch((err) => this.emit('error', err))
+      .catch((err) => {
+        if (!this._aborted) this.emit('error', err)
+      })
+  }
+
+  abort() {
+    this._aborted = true
+    this.buffer = EMPTY_BUFFER
+    this.pendingChunks = []
   }
 
   _downmixToStereo(interleavedPCM, channels, samplesPerChannel) {
-    if (channels === 2) return interleavedPCM
+    if (channels === AUDIO_CONFIG.channels) return interleavedPCM
 
     const stereo = new Float32Array(samplesPerChannel * 2)
+    const { center, surround, lfe } = DOWNMIX_COEFFICIENTS
 
     if (channels === 1) {
       for (let i = 0; i < samplesPerChannel; i++) {
-        const val = interleavedPCM[i]
-        stereo[i * 2] = val
-        stereo[i * 2 + 1] = val
+        const value = interleavedPCM[i]
+        stereo[i * 2] = value
+        stereo[i * 2 + 1] = value
       }
       return stereo
     }
 
-    const CENTER_MIX = 0.7071
-    const SURROUND_MIX = 0.7071
-    const LFE_MIX = 0.5
-
     for (let i = 0; i < samplesPerChannel; i++) {
+      const offset = i * channels
       let left = 0
       let right = 0
-      const offset = i * channels
 
       switch (channels) {
-        case 3: {
-          const C = interleavedPCM[offset]
-          const L = interleavedPCM[offset + 1]
-          const R = interleavedPCM[offset + 2]
-          left = L + C * CENTER_MIX
-          right = R + C * CENTER_MIX
+        case 3:
+          left = interleavedPCM[offset + 1] + interleavedPCM[offset] * center
+          right = interleavedPCM[offset + 2] + interleavedPCM[offset] * center
           break
-        }
-        case 4: {
-          const C = interleavedPCM[offset]
-          const L = interleavedPCM[offset + 1]
-          const R = interleavedPCM[offset + 2]
-          const Cs = interleavedPCM[offset + 3]
-          left = L + C * CENTER_MIX + Cs * SURROUND_MIX * 0.5
-          right = R + C * CENTER_MIX + Cs * SURROUND_MIX * 0.5
+
+        case 4:
+          left = interleavedPCM[offset + 1] + interleavedPCM[offset] * center +
+                 interleavedPCM[offset + 3] * surround * 0.5
+          right = interleavedPCM[offset + 2] + interleavedPCM[offset] * center +
+                  interleavedPCM[offset + 3] * surround * 0.5
           break
-        }
-        case 5: {
-          const C = interleavedPCM[offset]
-          const L = interleavedPCM[offset + 1]
-          const R = interleavedPCM[offset + 2]
-          const Ls = interleavedPCM[offset + 3]
-          const Rs = interleavedPCM[offset + 4]
-          left = L + C * CENTER_MIX + Ls * SURROUND_MIX
-          right = R + C * CENTER_MIX + Rs * SURROUND_MIX
+
+        case 5:
+          left = interleavedPCM[offset + 1] + interleavedPCM[offset] * center +
+                 interleavedPCM[offset + 3] * surround
+          right = interleavedPCM[offset + 2] + interleavedPCM[offset] * center +
+                  interleavedPCM[offset + 4] * surround
           break
-        }
-        case 6: {
-          const C = interleavedPCM[offset]
-          const L = interleavedPCM[offset + 1]
-          const R = interleavedPCM[offset + 2]
-          const Ls = interleavedPCM[offset + 3]
-          const Rs = interleavedPCM[offset + 4]
-          const LFE = interleavedPCM[offset + 5]
-          left = L + C * CENTER_MIX + Ls * SURROUND_MIX + LFE * LFE_MIX
-          right = R + C * CENTER_MIX + Rs * SURROUND_MIX + LFE * LFE_MIX
+
+        case 6:
+          left = interleavedPCM[offset + 1] + interleavedPCM[offset] * center +
+                 interleavedPCM[offset + 3] * surround + interleavedPCM[offset + 5] * lfe
+          right = interleavedPCM[offset + 2] + interleavedPCM[offset] * center +
+                  interleavedPCM[offset + 4] * surround + interleavedPCM[offset + 5] * lfe
           break
-        }
+
         default:
           left = interleavedPCM[offset]
           right = interleavedPCM[offset + 1] || left
-          break
       }
 
-      if (left > 1.0) left = 1.0
-      else if (left < -1.0) left = -1.0
-      if (right > 1.0) right = 1.0
-      else if (right < -1.0) right = -1.0
-
-      stereo[i * 2] = left
-      stereo[i * 2 + 1] = right
+      stereo[i * 2] = _clampSample(left)
+      stereo[i * 2 + 1] = _clampSample(right)
     }
 
     return stereo
   }
 
   async _processPendingChunks() {
-    if (!this.isDecoderReady || this.pendingChunks.length === 0) return
+    if (!this.isDecoderReady || this.pendingChunks.length === 0 || this._aborted) return
 
-    for (const { chunk, encoding, callback } of this.pendingChunks) {
+    const chunks = this.pendingChunks
+    this.pendingChunks = []
+
+    for (const { chunk, encoding, callback } of chunks) {
+      if (this._aborted) {
+        callback()
+        continue
+      }
       await this._decodeChunk(chunk, encoding, callback)
     }
-    this.pendingChunks = []
   }
 
   _findADTSFrame(buffer) {
-    for (let i = 0; i < buffer.length - 7; i++) {
+    const minLength = 7
+
+    for (let i = 0; i < buffer.length - minLength; i++) {
       const syncword = (buffer[i] << 4) | (buffer[i + 1] >> 4)
+
       if (syncword === 0xfff) {
-        const frameLength =
-          ((buffer[i + 3] & 0x03) << 11) |
-          (buffer[i + 4] << 3) |
-          ((buffer[i + 5] >> 5) & 0x07)
+        const frameLength = ((buffer[i + 3] & 0x03) << 11) |
+                           (buffer[i + 4] << 3) |
+                           ((buffer[i + 5] >> 5) & 0x07)
 
         if (i + frameLength <= buffer.length) {
           return {
@@ -737,19 +756,29 @@ class AACDecoderStream extends Transform {
         break
       }
     }
+
     return null
   }
 
   _transform(chunk, encoding, callback) {
+    if (this._aborted) {
+      callback()
+      return
+    }
+
     if (!this.isDecoderReady) {
       this.pendingChunks.push({ chunk, encoding, callback })
       return
     }
-
     this._decodeChunk(chunk, encoding, callback)
   }
 
   async _decodeChunk(chunk, encoding, callback) {
+    if (this._aborted || !this.decoder) {
+      callback()
+      return
+    }
+
     try {
       this.buffer = Buffer.concat([this.buffer, chunk])
 
@@ -768,64 +797,7 @@ class AACDecoderStream extends Transform {
         }
       }
 
-      while (this.buffer.length > 0) {
-        const frameInfo = this._findADTSFrame(this.buffer)
-
-        if (!frameInfo) break
-
-        try {
-          const result = this.decoder.decode(frameInfo.frame)
-
-          if (result?.pcm && result.pcm.length > 0) {
-            let { pcm, sampleRate, channels, samplesPerChannel } = result
-
-            if (channels > 2 || channels === 1) {
-              pcm = this._downmixToStereo(pcm, channels, samplesPerChannel)
-              channels = 2
-            }
-
-            if (sampleRate !== 48000) {
-              if (!this.resampler && !this.resamplerCreationPromise) {
-                this.resamplerCreationPromise = LibSampleRate.create(
-                  2,
-                  sampleRate,
-                  48000,
-                  {
-                    converterType: _getResamplerConverterType(
-                      this.resamplingQuality
-                    )
-                  }
-                ).then((resampler) => {
-                  this.resampler = resampler
-                  this.resamplerCreationPromise = null
-                  return resampler
-                })
-              }
-
-              if (!this.resampler) {
-                await this.resamplerCreationPromise
-              }
-
-              const resampled = this.resampler.full(pcm)
-              const pcmInt16 = new Int16Array(resampled.length)
-              for (let i = 0; i < resampled.length; i++) {
-                pcmInt16[i] = Math.max(-1, Math.min(1, resampled[i])) * 32767
-              }
-              this.push(Buffer.from(pcmInt16.buffer))
-            } else {
-              const pcmInt16 = new Int16Array(pcm.length)
-              for (let i = 0; i < pcm.length; i++) {
-                pcmInt16[i] = Math.max(-1, Math.min(1, pcm[i])) * 32767
-              }
-              this.push(Buffer.from(pcmInt16.buffer))
-            }
-          }
-        } catch (decodeErr) {
-          // Skip bad frame
-        }
-
-        this.buffer = this.buffer.subarray(frameInfo.end)
-      }
+      await this._decodeFrames()
 
       callback()
     } catch (err) {
@@ -833,111 +805,215 @@ class AACDecoderStream extends Transform {
     }
   }
 
+  async _decodeFrames() {
+    let framesDecoded = 0
+    const maxFramesPerCall = 5
+
+    while (this.buffer.length > 0 && framesDecoded < maxFramesPerCall && !this._aborted && this.decoder) {
+      const frameInfo = this._findADTSFrame(this.buffer)
+      if (!frameInfo) break
+
+      try {
+        const result = this.decoder?.decode(frameInfo.frame)
+
+        if (result?.pcm?.length > 0 && !this._aborted) {
+          await this._processDecodedFrame(result)
+          framesDecoded++
+        }
+      } catch {}
+
+      this.buffer = this.buffer.subarray(frameInfo.end)
+    }
+  }
+
+  async _processDecodedFrame(result) {
+    if (this._aborted) return
+
+    let { pcm, sampleRate, channels, samplesPerChannel } = result
+
+    if (channels !== AUDIO_CONFIG.channels) {
+      pcm = this._downmixToStereo(pcm, channels, samplesPerChannel)
+    }
+
+    if (sampleRate !== AUDIO_CONFIG.sampleRate) {
+      await this._ensureResampler(sampleRate)
+      if (!this._aborted && this.resampler) {
+        this.push(_floatToInt16Buffer(this.resampler.full(pcm)))
+      }
+    } else if (!this._aborted) {
+      this.push(_floatToInt16Buffer(pcm))
+    }
+  }
+
+  async _ensureResampler(sampleRate) {
+    if (this._aborted) return
+
+    if (!this.resampler && !this.resamplerCreationPromise) {
+      this.resamplerCreationPromise = LibSampleRate.create(
+        AUDIO_CONFIG.channels,
+        sampleRate,
+        AUDIO_CONFIG.sampleRate,
+        { converterType: _getResamplerConverterType(this.resamplingQuality) }
+      ).then((resampler) => {
+        this.resampler = resampler
+        this.resamplerCreationPromise = null
+        return resampler
+      })
+    }
+
+    if (!this.resampler) {
+      await this.resamplerCreationPromise
+    }
+  }
+
   _flush(callback) {
+    if (this._aborted || !this.decoder) {
+      this._cleanup()
+      callback()
+      return
+    }
+
     if (this.buffer.length > 0 && this.isConfigured) {
       try {
         const frameInfo = this._findADTSFrame(this.buffer)
         if (frameInfo) {
-          const result = this.decoder.decode(frameInfo.frame)
+          const result = this.decoder?.decode(frameInfo.frame)
           if (result?.pcm) {
-            const pcmInt16 = new Int16Array(result.pcm.length)
-            for (let i = 0; i < result.pcm.length; i++) {
-              pcmInt16[i] = Math.max(-1, Math.min(1, result.pcm[i])) * 32767
-            }
-            this.push(Buffer.from(pcmInt16.buffer))
+            this.push(_floatToInt16Buffer(result.pcm))
           }
         }
-      } catch (err) {}
+      } catch {}
     }
 
-    if (this.resampler) this.resampler.destroy?.()
-    if (this.decoder) this.decoder.destroy?.()
+    this._cleanup()
     callback()
+  }
+
+  _destroy(err, callback) {
+    this._aborted = true
+
+    for (const { callback: cb } of this.pendingChunks) {
+      cb()
+    }
+    this.pendingChunks = []
+    this.buffer = EMPTY_BUFFER
+
+    this._cleanup()
+    super._destroy(err, callback)
+  }
+
+  _cleanup() {
+    if (this.resampler) {
+      try {
+        this.resampler.destroy()
+      } catch {}
+      this.resampler = null
+    }
+
+    if (this.decoder) {
+      try {
+        this.decoder.destroy()
+      } catch {}
+      this.decoder = null
+    }
   }
 }
 
 class MP4ToAACStream extends Transform {
   constructor(options) {
-    super(options)
+    super({
+      ...options,
+      highWaterMark: AUDIO_CONFIG.highWaterMark
+    })
+
     this.mp4boxFile = MP4Box.createFile()
     this.audioConfig = null
     this.offset = 0
     this.isReady = false
+    this._aborted = false
 
+    this._setupMP4BoxHandlers()
+  }
+
+  abort() {
+    this._aborted = true
+    this._cleanupMp4Box()
+  }
+
+  _setupMP4BoxHandlers() {
     this.mp4boxFile.onReady = (info) => {
+      if (this._aborted) return
+
       try {
         const audioTrack = info.tracks.find((t) => t.codec?.startsWith('mp4a'))
+
         if (!audioTrack) {
           this.emit('error', new Error('No AAC track found in MP4'))
           return
         }
 
         this.audioConfig = this._getAudioConfig(audioTrack)
-        this.mp4boxFile.setExtractionOptions(audioTrack.id, null, {
-          nbSamples: 1
-        })
+        this.mp4boxFile.setExtractionOptions(audioTrack.id, null, { nbSamples: 1 })
         this.mp4boxFile.start()
         this.isReady = true
       } catch (err) {
-        this.emit(
-          'error',
-          new Error(`MP4 initialization error: ${err.message}`)
-        )
+        this.emit('error', new Error(`MP4 initialization error: ${err.message}`))
       }
     }
 
     this.mp4boxFile.onSamples = (id, user, samples) => {
+      if (this._aborted) return
+
       try {
         if (!samples || !Array.isArray(samples)) return
 
         for (const sample of samples) {
-          if (sample?.data) {
-            const adts = this._createAdtsHeader(
-              sample.data.byteLength,
-              this.audioConfig
-            )
-            const sampleData =
-              sample.data instanceof ArrayBuffer
-                ? Buffer.from(sample.data)
-                : Buffer.from(sample.data.buffer || sample.data)
-
-            this.push(adts)
-            this.push(sampleData)
+          if (sample?.data && !this._aborted) {
+            this._emitSampleWithADTS(sample)
           }
         }
       } catch (err) {
-        this.emit(
-          'error',
-          new Error(`MP4Box sample processing error: ${err.message}`)
-        )
+        if (!this._aborted) {
+          this.emit('error', new Error(`MP4Box sample processing error: ${err.message}`))
+        }
       }
     }
 
     this.mp4boxFile.onError = (e) => {
-      this.emit('error', new Error(`MP4Box error: ${e}`))
+      if (!this._aborted) {
+        this.emit('error', new Error(`MP4Box error: ${e}`))
+      }
     }
   }
 
+  _emitSampleWithADTS(sample) {
+    const { profile, samplingIndex, channelCount } = this.audioConfig
+
+    const sampleData = sample.data instanceof ArrayBuffer
+      ? Buffer.from(sample.data)
+      : Buffer.from(sample.data.buffer || sample.data)
+
+    this.push(_createAdtsHeader(sampleData.byteLength, profile, samplingIndex, channelCount))
+    this.push(sampleData)
+  }
+
   _getAudioConfig(track) {
-    const sampleRates = [
-      96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 12000,
-      11025, 8000, 7350
-    ]
-    let samplingIndex = sampleRates.indexOf(track.audio.sample_rate)
-    if (samplingIndex === -1)
+    let samplingIndex = SAMPLE_RATES.indexOf(track.audio.sample_rate)
+
+    if (samplingIndex === -1) {
       throw new Error('Unsupported sample rate for ADTS')
+    }
 
     let profile = 2
 
     if (track.codec) {
       const codecParts = track.codec.split('.')
+
       if (codecParts.length >= 3) {
         const objectType = Number.parseInt(codecParts[2], 10)
 
         if (objectType === 5) {
-          profile = 2
-          const coreSampleRate = track.audio.sample_rate / 2
-          const coreSamplingIndex = sampleRates.indexOf(coreSampleRate)
+          const coreSamplingIndex = SAMPLE_RATES.indexOf(track.audio.sample_rate / 2)
           if (coreSamplingIndex !== -1) {
             samplingIndex = coreSamplingIndex
           }
@@ -954,139 +1030,87 @@ class MP4ToAACStream extends Transform {
     }
   }
 
-  _createAdtsHeader(sampleLength, audioConfig) {
-    const adts = Buffer.alloc(7)
-    const frameLength = sampleLength + 7
-
-    const profile = audioConfig.profile - 1
-    const samplingIndex = audioConfig.samplingIndex
-    const channelCount = audioConfig.channelCount
-
-    adts[0] = 0xff
-    adts[1] = 0xf1
-    adts[2] =
-      ((profile & 0x03) << 6) |
-      ((samplingIndex & 0x0f) << 2) |
-      ((channelCount & 0x04) >> 2)
-    adts[3] = ((channelCount & 0x03) << 6) | ((frameLength & 0x1800) >> 11)
-    adts[4] = (frameLength & 0x7f8) >> 3
-    adts[5] = ((frameLength & 0x7) << 5) | 0x1f
-    adts[6] = 0xfc
-
-    return adts
-  }
-
   _transform(chunk, encoding, callback) {
+    if (this._aborted || !this.mp4boxFile) {
+      callback()
+      return
+    }
+
     try {
-      const arrayBuffer =
-        chunk instanceof ArrayBuffer
-          ? chunk
-          : chunk.buffer.slice(
-              chunk.byteOffset,
-              chunk.byteOffset + chunk.byteLength
-            )
+      const arrayBuffer = chunk instanceof ArrayBuffer
+        ? chunk
+        : chunk.buffer.slice(chunk.byteOffset, chunk.byteOffset + chunk.byteLength)
 
       arrayBuffer.fileStart = this.offset
       this.offset += arrayBuffer.byteLength
 
       this.mp4boxFile.appendBuffer(arrayBuffer)
       callback()
-    } catch (err) {
+    } catch {
       callback()
     }
   }
 
   _flush(callback) {
-    try {
-      if (this.mp4boxFile) {
+    if (!this._aborted && this.mp4boxFile) {
+      try {
         this.mp4boxFile.flush()
-      }
-      callback()
-    } catch (err) {
-      callback()
+      } catch {}
     }
+    this._cleanupMp4Box()
+    callback()
   }
 
   _destroy(err, callback) {
+    this._aborted = true
+    this._cleanupMp4Box()
+    super._destroy(err, callback)
+  }
+
+  _cleanupMp4Box() {
     if (this.mp4boxFile) {
-      this.mp4boxFile.stop()
+      try {
+        this.mp4boxFile.stop()
+      } catch {}
       this.mp4boxFile.onReady = null
       this.mp4boxFile.onSamples = null
       this.mp4boxFile.onError = null
       this.mp4boxFile = null
     }
-    super._destroy(err, callback)
   }
 }
 
 class FMP4ToAACStream extends Transform {
   constructor(options) {
-    super(options)
+    super({
+      ...options,
+      highWaterMark: AUDIO_CONFIG.highWaterMark
+    })
     this.audioConfig = null
     this.initSegmentProcessed = false
+    this._aborted = false
   }
 
-  _parseBoxes(buffer, offset = 0) {
-    const boxes = []
-    while (offset < buffer.length) {
-      if (offset + 8 > buffer.length) break
-
-      const size = buffer.readUInt32BE(offset)
-      const type = buffer.toString('ascii', offset + 4, offset + 8)
-
-      if (size === 0 || size > buffer.length - offset) break
-      if (type === '\0\0\0\0') break
-
-      const boxData = buffer.subarray(offset + 8, offset + size)
-      boxes.push({ type, size, data: boxData, offset })
-      offset += size
-    }
-    return boxes
+  abort() {
+    this._aborted = true
   }
 
   _extractAudioConfigFromInit(initSegment) {
-    const boxes = this._parseBoxes(initSegment)
-    const moovBox = boxes.find((b) => b.type === 'moov')
-    if (!moovBox) return null
+    const boxes = _parseBoxes(initSegment)
 
-    const moovBoxes = this._parseBoxes(moovBox.data)
-    const trakBox = moovBoxes.find((b) => b.type === 'trak')
-    if (!trakBox) return null
+    const stblBoxes = _findNestedBox(boxes, 'moov', 'trak', 'mdia', 'minf', 'stbl')
+    if (!stblBoxes) return null
 
-    const trakBoxes = this._parseBoxes(trakBox.data)
-    const mdiaBox = trakBoxes.find((b) => b.type === 'mdia')
-    if (!mdiaBox) return null
-
-    const mdiaBoxes = this._parseBoxes(mdiaBox.data)
-    const minfBox = mdiaBoxes.find((b) => b.type === 'minf')
-    if (!minfBox) return null
-
-    const minfBoxes = this._parseBoxes(minfBox.data)
-    const stblBox = minfBoxes.find((b) => b.type === 'stbl')
-    if (!stblBox) return null
-
-    const stblBoxes = this._parseBoxes(stblBox.data)
     const stsdBox = stblBoxes.find((b) => b.type === 'stsd')
-    if (!stsdBox) return null
+    if (!stsdBox || stsdBox.data.length < 16) return null
 
-    const stsd = stsdBox.data
-    if (stsd.length < 16) return null
-
-    const stsdBoxes = this._parseBoxes(stsd, 8)
-    const mp4aBox = stsdBoxes.find((b) => b.type === 'mp4a')
-    if (!mp4aBox) return null
+    const mp4aBox = _parseBoxes(stsdBox.data, 8).find((b) => b.type === 'mp4a')
+    if (!mp4aBox || mp4aBox.data.length < 28) return null
 
     const mp4a = mp4aBox.data
-    if (mp4a.length < 28) return null
-
     const channelCount = mp4a.readUInt16BE(16)
     const sampleRate = mp4a.readUInt32BE(24) >> 16
-
-    const sampleRates = [
-      96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050, 16000, 12000,
-      11025, 8000, 7350
-    ]
-    const samplingIndex = sampleRates.indexOf(sampleRate)
+    const samplingIndex = SAMPLE_RATES.indexOf(sampleRate)
 
     return {
       profile: 2,
@@ -1096,59 +1120,48 @@ class FMP4ToAACStream extends Transform {
     }
   }
 
-  _createAdtsHeader(sampleLength, audioConfig) {
-    const adts = Buffer.alloc(7)
-    const frameLength = sampleLength + 7
-
-    const profile = (audioConfig.profile || 2) - 1
-    const samplingIndex = audioConfig.samplingIndex || 4
-    const channelCount = audioConfig.channelCount || 2
-
-    adts[0] = 0xff
-    adts[1] = 0xf1
-    adts[2] =
-      ((profile & 0x03) << 6) |
-      ((samplingIndex & 0x0f) << 2) |
-      ((channelCount & 0x04) >> 2)
-    adts[3] = ((channelCount & 0x03) << 6) | ((frameLength & 0x1800) >> 11)
-    adts[4] = (frameLength & 0x7f8) >> 3
-    adts[5] = ((frameLength & 0x7) << 5) | 0x1f
-    adts[6] = 0xfc
-
-    return adts
-  }
-
   _extractAACFromSegment(buffer) {
     if (!this.audioConfig) return null
 
-    const boxes = this._parseBoxes(buffer)
+    const boxes = _parseBoxes(buffer)
+
     const mdatBox = boxes.find((b) => b.type === 'mdat')
     if (!mdatBox) return null
 
     const aacData = mdatBox.data
+
+    const sampleSizes = this._extractSampleSizes(boxes)
+
+    if (sampleSizes && sampleSizes.length > 0) {
+      return this._wrapSamplesWithADTS(aacData, sampleSizes)
+    }
+
+    return null
+  }
+
+  _extractSampleSizes(boxes) {
     const moofBox = boxes.find((b) => b.type === 'moof')
-    if (!moofBox) return aacData
+    if (!moofBox) return null
 
-    const moofBoxes = this._parseBoxes(moofBox.data)
+    const moofBoxes = _parseBoxes(moofBox.data)
     const trafBox = moofBoxes.find((b) => b.type === 'traf')
-    if (!trafBox) return aacData
+    if (!trafBox) return null
 
-    const trafBoxes = this._parseBoxes(trafBox.data)
+    const trafBoxes = _parseBoxes(trafBox.data)
     const trunBox = trafBoxes.find((b) => b.type === 'trun')
-    if (!trunBox) return aacData
+    if (!trunBox || trunBox.data.length < 8) return null
 
     const trun = trunBox.data
-    if (trun.length < 8) return aacData
-
     const flags = (trun[1] << 16) | (trun[2] << 8) | trun[3]
     const sampleCount = trun.readUInt32BE(4)
 
     let offset = 8
+
     if (flags & 0x1) offset += 4
     if (flags & 0x4) offset += 4
 
     const sampleSizes = []
-    const hasSampleSize = flags & 0x200
+    const hasSampleSize = !!(flags & 0x200)
 
     for (let i = 0; i < sampleCount && offset < trun.length; i++) {
       if (flags & 0x100) offset += 4
@@ -1160,33 +1173,35 @@ class FMP4ToAACStream extends Transform {
       if (flags & 0x800) offset += 4
     }
 
-    if (sampleSizes.length > 0) {
-      const frames = []
-      let dataOffset = 0
-      for (const sampleSize of sampleSizes) {
-        if (dataOffset + sampleSize <= aacData.length) {
-          const adtsHeader = this._createAdtsHeader(
-            sampleSize,
-            this.audioConfig
-          )
-          const aacSample = aacData.subarray(
-            dataOffset,
-            dataOffset + sampleSize
-          )
-          frames.push(Buffer.concat([adtsHeader, aacSample]))
-          dataOffset += sampleSize
-        }
+    return sampleSizes
+  }
+
+  _wrapSamplesWithADTS(aacData, sampleSizes) {
+    const { profile, samplingIndex, channelCount } = this.audioConfig
+    const frames = []
+    let dataOffset = 0
+
+    for (const sampleSize of sampleSizes) {
+      if (dataOffset + sampleSize <= aacData.length) {
+        frames.push(_createAdtsHeader(sampleSize, profile, samplingIndex, channelCount))
+        frames.push(aacData.subarray(dataOffset, dataOffset + sampleSize))
+        dataOffset += sampleSize
       }
-      return frames.length > 0 ? Buffer.concat(frames) : null
     }
 
-    return null
+    return frames.length > 0 ? Buffer.concat(frames) : null
   }
 
   _transform(chunk, encoding, callback) {
+    if (this._aborted) {
+      callback()
+      return
+    }
+
     try {
       if (!this.initSegmentProcessed && chunk.length > 8) {
         const boxType = chunk.toString('ascii', 4, 8)
+
         if (boxType === 'ftyp') {
           this.audioConfig = this._extractAudioConfigFromInit(chunk)
           this.initSegmentProcessed = true
@@ -1195,7 +1210,7 @@ class FMP4ToAACStream extends Transform {
         }
       }
 
-      if (this.audioConfig) {
+      if (this.audioConfig && !this._aborted) {
         const aacData = this._extractAACFromSegment(chunk)
         if (aacData) {
           this.push(aacData)
@@ -1203,7 +1218,7 @@ class FMP4ToAACStream extends Transform {
       }
 
       callback()
-    } catch (err) {
+    } catch {
       callback()
     }
   }
@@ -1211,59 +1226,10 @@ class FMP4ToAACStream extends Transform {
   _flush(callback) {
     callback()
   }
-}
 
-class WAVDecoderStream extends Transform {
-  constructor(options) {
-    super(options)
-    this.headerParsed = false
-    this.headerBuffer = Buffer.alloc(0)
-  }
-
-  _transform(chunk, encoding, callback) {
-    try {
-      if (!this.headerParsed) {
-        this.headerBuffer = Buffer.concat([this.headerBuffer, chunk])
-
-        if (this.headerBuffer.length >= 44) {
-          const riff = this.headerBuffer.toString('ascii', 0, 4)
-          const wave = this.headerBuffer.toString('ascii', 8, 12)
-
-          if (riff === 'RIFF' && wave === 'WAVE') {
-            let dataPos = 12
-            while (dataPos < this.headerBuffer.length - 8) {
-              const chunkId = this.headerBuffer.toString(
-                'ascii',
-                dataPos,
-                dataPos + 4
-              )
-              const chunkSize = this.headerBuffer.readUInt32LE(dataPos + 4)
-
-              if (chunkId === 'data') {
-                const audioData = this.headerBuffer.subarray(dataPos + 8)
-                if (audioData.length > 0) {
-                  this.push(audioData)
-                }
-                this.headerParsed = true
-                break
-              }
-
-              dataPos += 8 + chunkSize
-            }
-          }
-        }
-
-        if (!this.headerParsed) {
-          return callback()
-        }
-      } else {
-        this.push(chunk)
-      }
-
-      callback()
-    } catch (err) {
-      callback()
-    }
+  _destroy(err, callback) {
+    this._aborted = true
+    super._destroy(err, callback)
   }
 }
 
@@ -1271,156 +1237,153 @@ class StreamAudioResource extends BaseAudioResource {
   constructor(stream, type, nodelink, initialFilters = {}, volume = 1.0) {
     super()
 
-    try {
-      if (!stream || !(stream instanceof Readable)) {
-        throw new Error('Invalid stream provided')
-      }
+    this._validateInputStream(stream)
 
-      const resamplingQuality = nodelink.options.audio.resamplingQuality
-      const normalizedType = normalizeFormat(type)
-      let pcmStream
+    const resamplingQuality = nodelink.options.audio.resamplingQuality || 'fastest'
+    const normalizedType = normalizeFormat(type)
 
-      this.pipes = [stream]
+    this.pipes = [stream]
 
-      switch (normalizedType) {
-        case SupportedFormats.AAC: {
-          const lowerType = type.toLowerCase()
-          let aacStream = stream
+    const pcmStream = this._createDecoderPipeline(
+      stream,
+      type,
+      normalizedType,
+      resamplingQuality
+    )
 
-          if (
-            lowerType.includes('fmp4') ||
-            lowerType.includes('hls') ||
-            lowerType.includes('mpegurl')
-          ) {
-            const fmp4ToAAC = new FMP4ToAACStream()
-            aacStream = stream.pipe(fmp4ToAAC)
-            this.pipes.push(fmp4ToAAC)
-          } else if (
-            lowerType.includes('mpegts') ||
-            lowerType.includes('video/mp2t')
-          ) {
-            const mpegtsToAAC = new MPEGTSToAACStream()
-            aacStream = stream.pipe(mpegtsToAAC)
-            this.pipes.push(mpegtsToAAC)
-          } else if (
-            lowerType.includes('mp4') ||
-            lowerType.includes('m4a') ||
-            lowerType.includes('m4v') ||
-            lowerType.includes('mov')
-          ) {
-            const mp4ToAAC = new MP4ToAACStream()
-            aacStream = stream.pipe(mp4ToAAC)
-            this.pipes.push(mp4ToAAC)
-          }
+    this._createOutputPipeline(pcmStream, nodelink, initialFilters, volume)
+    this._setupEventHandlers(stream)
+  }
 
-          const aacDecoder = new AACDecoderStream({ resamplingQuality })
-          pcmStream = aacStream.pipe(aacDecoder)
-          this.pipes.push(aacDecoder)
-          break
-        }
-        case SupportedFormats.MPEG: {
-          const mpegDecoder = new MpegDecoderStream({ resamplingQuality })
-          pcmStream = stream.pipe(mpegDecoder)
-          this.pipes.push(mpegDecoder)
-          break
-        }
-        case SupportedFormats.FLAC: {
-          const flacDecoder = new FLACDecoderStream({ resamplingQuality })
-          pcmStream = stream.pipe(flacDecoder)
-          this.pipes.push(flacDecoder)
-          break
-        }
-        case SupportedFormats.OGG_VORBIS: {
-          const vorbisDecoder = new OggVorbisDecoderStream({
-            resamplingQuality
-          })
-          pcmStream = stream.pipe(vorbisDecoder)
-          this.pipes.push(vorbisDecoder)
-          break
-        }
-        case SupportedFormats.WAV: {
-          pcmStream = stream
-          break
-        }
-        case SupportedFormats.OPUS: {
-          const lowerType = type.toLowerCase()
-          const decoder = new OpusDecoder({
-            rate: 48000,
-            channels: 2,
-            frameSize: 960
-          })
-          if (lowerType.includes('webm')) {
-            const demuxer = new WebmOpusDemuxer()
-            pcmStream = stream.pipe(demuxer).pipe(decoder)
-            this.pipes.push(demuxer, decoder)
-          } else {
-            pcmStream = stream.pipe(decoder)
-            this.pipes.push(decoder)
-          }
-          break
-        }
-        default: {
-          const supportedFormatsList = [
-            'MP3 (audio/mpeg)',
-            'AAC (audio/aac, audio/aacp, mp4, m4a, m4v, mov, hls, mpegurl, fmp4, mpegts)',
-            'FLAC (audio/flac)',
-            'OGG Vorbis (audio/ogg, audio/vorbis)',
-            'WAV (audio/wav)',
-            'Opus (webm/opus, ogg/opus)'
-          ]
+  _validateInputStream(stream) {
+    if (!stream || !(stream instanceof Readable)) {
+      throw new Error('Invalid stream provided')
+    }
+  }
 
-          throw new Error(
-            `Unsupported audio format: "${type}".\n` +
-              `Supported formats:\n${supportedFormatsList.map((f) => `  • ${f}`).join('\n')}`
-          )
-        }
-      }
+  _createDecoderPipeline(stream, type, normalizedType, resamplingQuality) {
+    switch (normalizedType) {
+      case SupportedFormats.AAC:
+        return this._createAACPipeline(stream, type, resamplingQuality)
 
-      const volumeTransformer = new VolumeTransformer({ type: 's16le', volume })
-      const filters = new FiltersManager(nodelink, initialFilters)
-      const opus = new OpusEncoder({
-        rate: 48000,
-        channels: 2,
-        frameSize: 960
-      })
+      case SupportedFormats.MPEG:
+      case SupportedFormats.FLAC:
+      case SupportedFormats.OGG_VORBIS:
+      case SupportedFormats.WAV:
+        return this._createSymphoniaPipeline(stream, resamplingQuality)
 
-      pcmStream.pipe(volumeTransformer).pipe(filters).pipe(opus)
+      case SupportedFormats.OPUS:
+        return this._createOpusPipeline(stream, type)
 
-      this.pipes.push(volumeTransformer, filters, opus)
-      this.stream = opus
+      default:
+        throw this._createUnsupportedFormatError(type)
+    }
+  }
 
-      stream.on('finishBuffering', () => this.stream.emit('finishBuffering'))
+  _createAACPipeline(stream, type, resamplingQuality) {
+    const lowerType = type.toLowerCase()
+    let aacStream = stream
 
-      stream.on('error', (err) => {
-        console.error('Error in input stream:', err)
-        this.stream?.emit('error', err)
-      })
+    if (_isFmp4Format(lowerType)) {
+      const demuxer = new FMP4ToAACStream()
+      aacStream = stream.pipe(demuxer)
+      this.pipes.push(demuxer)
+    } else if (_isMpegtsFormat(lowerType)) {
+      const demuxer = new MPEGTSToAACStream()
+      aacStream = stream.pipe(demuxer)
+      this.pipes.push(demuxer)
+    } else if (_isMp4Format(lowerType)) {
+      const demuxer = new MP4ToAACStream()
+      aacStream = stream.pipe(demuxer)
+      this.pipes.push(demuxer)
+    }
 
-      for (const pipe of this.pipes) {
-        if (pipe === this.stream) continue
+    const decoder = new AACDecoderStream({ resamplingQuality })
+    this.pipes.push(decoder)
+
+    return aacStream.pipe(decoder)
+  }
+
+  _createSymphoniaPipeline(stream, resamplingQuality) {
+    const decoder = new SymphoniaDecoderStream({ resamplingQuality })
+    this.pipes.push(decoder)
+    return stream.pipe(decoder)
+  }
+
+  _createOpusPipeline(stream, type) {
+    const decoder = new OpusDecoder({
+      rate: AUDIO_CONFIG.sampleRate,
+      channels: AUDIO_CONFIG.channels,
+      frameSize: AUDIO_CONFIG.frameSize
+    })
+
+    if (_isWebmFormat(type.toLowerCase())) {
+      const demuxer = new WebmOpusDemuxer()
+      this.pipes.push(demuxer, decoder)
+      return stream.pipe(demuxer).pipe(decoder)
+    }
+
+    this.pipes.push(decoder)
+    return stream.pipe(decoder)
+  }
+
+  _createOutputPipeline(pcmStream, nodelink, initialFilters, volume) {
+    const volumeTransformer = new VolumeTransformer({ type: 's16le', volume })
+    const filters = new FiltersManager(nodelink, initialFilters)
+    const opusEncoder = new OpusEncoder({
+      rate: AUDIO_CONFIG.sampleRate,
+      channels: AUDIO_CONFIG.channels,
+      frameSize: AUDIO_CONFIG.frameSize
+    })
+
+    pcmStream.pipe(volumeTransformer).pipe(filters).pipe(opusEncoder)
+
+    this.pipes.push(volumeTransformer, filters, opusEncoder)
+    this.stream = opusEncoder
+  }
+
+  _setupEventHandlers(inputStream) {
+    inputStream.on('finishBuffering', () => {
+      this.stream?.emit('finishBuffering')
+    })
+
+    inputStream.on('error', (err) => {
+      this.stream?.emit('error', err)
+    })
+
+    for (const pipe of this.pipes) {
+      if (pipe !== this.stream) {
         pipe.on?.('error', (err) => {
-          console.error(`Error in stream pipe ${pipe.constructor.name}:`, err)
           this.stream?.emit('error', err)
         })
       }
-
-      this.stream.on('error', (err) => {
-        console.error('Error in opus encoder:', err)
-        this._end()
-      })
-    } catch (err) {
-      throw new Error(`Failed to create audio resource: ${err.message}`)
     }
+
+    this.stream.on('error', () => {
+      this._end()
+    })
+  }
+
+  _createUnsupportedFormatError(type) {
+    const supportedFormats = [
+      'MP3 (audio/mpeg)',
+      'AAC (audio/aac, audio/aacp, mp4, m4a, m4v, mov, hls, mpegurl, fmp4, mpegts)',
+      'FLAC (audio/flac)',
+      'OGG Vorbis (audio/ogg, audio/vorbis)',
+      'WAV (audio/wav)',
+      'Opus (webm/opus, ogg/opus)'
+    ]
+
+    return new Error(
+      `Unsupported audio format: '${type}'.\n` +
+      'Supported formats:\n' +
+      supportedFormats.map((f) => `  • ${f}`).join('\n')
+    )
   }
 }
 
-export const createAudioResource = (
-  stream,
-  type,
-  nodelink,
-  initialFilters = {},
-  volume = 1.0
-) => new StreamAudioResource(stream, type, nodelink, initialFilters, volume)
+export const createAudioResource = (stream, type, nodelink, initialFilters = {}, volume = 1.0) =>
+  new StreamAudioResource(stream, type, nodelink, initialFilters, volume)
 
 export const createSeekeableAudioResource = async (
   url,
@@ -1434,41 +1397,26 @@ export const createSeekeableAudioResource = async (
   try {
     const { stream, meta } = await seekableStream(url, seekTime, endTime, {})
 
-    const newStream = new PassThrough()
-    stream.on('data', (chunk) => {
-      newStream.write(chunk)
-    })
+    const passthroughStream = new PassThrough({ highWaterMark: AUDIO_CONFIG.highWaterMark })
+
+    stream.on('data', (chunk) => passthroughStream.write(chunk))
     stream.on('end', () => {
-      newStream.end()
-      newStream.emit('finishBuffering')
+      passthroughStream.end()
+      passthroughStream.emit('finishBuffering')
     })
-    stream.on('error', (err) => {
-      newStream.emit('error', err)
-    })
+    stream.on('error', (err) => passthroughStream.emit('error', err))
+
+    const format = meta.codec?.container || player.streamInfo.format
 
     return new StreamAudioResource(
-      newStream,
-      meta.codec?.container || player.streamInfo.format,
+      passthroughStream,
+      format,
       nodelink,
       initialFilters,
       volume
     )
   } catch (err) {
-    if (err instanceof SeekError) {
-      return {
-        exception: {
-          message: err.message,
-          severity: 'fault',
-          cause: err.code
-        }
-      }
-    }
-    return {
-      exception: {
-        message: err.message,
-        severity: 'fault',
-        cause: 'UNKNOWN'
-      }
-    }
+    const cause = err instanceof SeekError ? err.code : 'UNKNOWN'
+    return _createErrorResponse(err.message, cause)
   }
 }


### PR DESCRIPTION
## Changes

Optimized the decoding loop system for an better performance (Processes up to 5 frames per tick (prevents event loop blocking)

Added controlled buffers for the symphonia decoder, which reduces the memory usage and the gc pressure

Used object.freeze() for objects that don't get updated, slightly faster property acess.

Improved the cleanup process.

Uses rubato for resampling the quality (can replace the libsimplerate for some formats), which is also faster and more performant (can also improve the quality!)

adds: @toddynnn/symphonia-decoder
removes: @wasm-audio-decoders/flac, @wasm-audio-decoders/ogg-vorbis, mpg123-decoder, sodium-native

## Why 

This pr adds an rust library for real time audio decoding, this improves the speed and performance by a lot, while also reducing the memory usage from the pure JS code.

This is valid for sources like deezer, soundcloud, etc ^^

## Checkmarks

- [ X ] The modified endpoints have been tested.
- [ X ] Used the same indentation as the rest of the project.
- [ X ] Still compatible with LavaLink clients.

## Additional information

The lib coded in rust is not open source yet, i'll make it later, all bugs can be reported to me so i will take a look

uses: https://crates.io/crates/symphonia and https://crates.io/crates/rubato for the rust code.
