### PR TITLE
add: implement audio mixing functionality with dynamic layer management

### DIFF
--- a/config.default.js
+++ b/config.default.js
@@ -260,5 +260,11 @@ export default {
       type: 'Bearer', // Bearer or Basic.
       password: '' // If empty, uses server.password
     }
+  },
+  mix: {
+    enabled: true,
+    defaultVolume: 0.8,
+    maxLayersMix: 5,
+    autoCleanup: true
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodelink",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "scripts": {
     "prebuild": "node scripts/prebuild.js",
     "start": "node --dns-result-order=ipv4first --openssl-legacy-provider src/index.js",

--- a/src/api/sessions.id.players.id.mix.id.js
+++ b/src/api/sessions.id.players.id.mix.id.js
@@ -1,0 +1,127 @@
+import myzod from 'myzod'
+import { logger, sendErrorResponse } from '../utils.js'
+
+const updateMixSchema = myzod
+  .object({
+    volume: myzod.number().min(0).max(1)
+  })
+  .allowUnknownKeys()
+
+const pathSchema = myzod.object({
+  sessionId: myzod.string(),
+  guildId: myzod
+    .string()
+    .withPredicate(
+      (val) => /^\d{17,20}$/.test(val),
+      'guildId must be 17-20 digits'
+    ),
+  mixId: myzod.string()
+})
+
+async function handler(nodelink, req, res, sendResponse, parsedUrl) {
+  const method = req.method
+  const pathParts = parsedUrl.pathname.split('/')
+  const sessionId = pathParts[3]
+  const guildId = pathParts[5]
+  const mixId = pathParts[7]
+
+  try {
+    pathSchema.parse({ sessionId, guildId, mixId })
+  } catch (error) {
+    if (error instanceof myzod.ValidationError) {
+      return sendErrorResponse(req, res, 400, error.message)
+    }
+    return sendErrorResponse(req, res, 400, 'Invalid path parameters')
+  }
+
+  if (method === 'PATCH') {
+    return handleUpdateMix(req, res, sessionId, guildId, mixId, nodelink)
+  }
+
+  if (method === 'DELETE') {
+    return handleDeleteMix(req, res, sessionId, guildId, mixId, nodelink)
+  }
+
+  return sendErrorResponse(req, res, 405, 'Method Not Allowed')
+}
+
+async function handleUpdateMix(req, res, sessionId, guildId, mixId, nodelink) {
+  try {
+    let body = req.body
+    if (typeof body === 'string') {
+      try {
+        body = JSON.parse(body)
+      } catch {
+        return sendErrorResponse(req, res, 400, 'Invalid JSON body')
+      }
+    }
+
+    updateMixSchema.parse(body)
+
+    const session = nodelink.sessions.get(sessionId)
+    if (!session) {
+      return sendErrorResponse(req, res, 404, 'Session not found')
+    }
+
+    if (!session.players) {
+      return sendErrorResponse(req, res, 500, 'Player manager not initialized')
+    }
+
+    const updated = await session.players.updateMix(
+      guildId,
+      mixId,
+      body.volume
+    )
+
+    if (!updated) {
+      return sendErrorResponse(req, res, 404, 'Mix not found')
+    }
+
+    logger(
+      'debug',
+      'MixAPI',
+      `Updated mix ${mixId} volume to ${body.volume} for guild ${guildId}`
+    )
+
+    res.writeHead(204)
+    res.end()
+  } catch (error) {
+    if (error instanceof myzod.ValidationError) {
+      return sendErrorResponse(req, res, 400, error.message)
+    }
+    logger('error', 'MixAPI', `Error updating mix: ${error.message}`)
+    return sendErrorResponse(req, res, 500, error.message)
+  }
+}
+
+async function handleDeleteMix(req, res, sessionId, guildId, mixId, nodelink) {
+  try {
+    const session = nodelink.sessions.get(sessionId)
+    if (!session) {
+      return sendErrorResponse(req, res, 404, 'Session not found')
+    }
+
+    if (!session.players) {
+      return sendErrorResponse(req, res, 500, 'Player manager not initialized')
+    }
+
+    const removed = await session.players.removeMix(guildId, mixId)
+
+    if (!removed) {
+      return sendErrorResponse(req, res, 404, 'Mix not found')
+    }
+
+    logger('debug', 'MixAPI', `Removed mix ${mixId} for guild ${guildId}`)
+
+    res.writeHead(204)
+    res.end()
+  } catch (error) {
+    logger('error', 'MixAPI', `Error removing mix: ${error.message}`)
+    return sendErrorResponse(req, res, 500, error.message)
+  }
+}
+
+export default {
+  handler,
+  methods: ['PATCH', 'DELETE']
+}

--- a/src/api/sessions.id.players.id.mix.js
+++ b/src/api/sessions.id.players.id.mix.js
@@ -1,0 +1,151 @@
+import myzod from 'myzod'
+import { decodeTrack, logger, sendErrorResponse, sendResponse } from '../utils.js'
+
+const mixTrackSchema = myzod
+  .object({
+    encoded: myzod.string().nullable().optional(),
+    identifier: myzod.string().optional(),
+    userData: myzod.unknown().optional()
+  })
+  .allowUnknownKeys()
+
+const createMixSchema = myzod
+  .object({
+    track: mixTrackSchema,
+    volume: myzod.number().min(0).max(1).optional()
+  })
+  .allowUnknownKeys()
+
+const pathSchema = myzod.object({
+  sessionId: myzod.string(),
+  guildId: myzod
+    .string()
+    .withPredicate(
+      (val) => /^\d{17,20}$/.test(val),
+      'guildId must be 17-20 digits'
+    )
+})
+
+async function handler(nodelink, req, res, sendResponse, parsedUrl) {
+  const method = req.method
+  const pathParts = parsedUrl.pathname.split('/')
+  const sessionId = pathParts[3]
+  const guildId = pathParts[5]
+
+  try {
+    pathSchema.parse({ sessionId, guildId })
+  } catch (error) {
+    if (error instanceof myzod.ValidationError) {
+      return sendErrorResponse(req, res, 400, error.message)
+    }
+    return sendErrorResponse(req, res, 400, 'Invalid path parameters')
+  }
+
+  if (method === 'POST') {
+    return handleCreateMix(req, res, sessionId, guildId, nodelink, sendResponse)
+  }
+
+  if (method === 'GET') {
+    return handleGetMixes(req, res, sessionId, guildId, nodelink, sendResponse)
+  }
+
+  return sendErrorResponse(req, res, 405, 'Method Not Allowed')
+}
+
+async function handleCreateMix(req, res, sessionId, guildId, nodelink, sendResponse) {
+  try {
+    let body = req.body
+    if (typeof body === 'string') {
+      try {
+        body = JSON.parse(body)
+      } catch {
+        return sendErrorResponse(req, res, 400, 'Invalid JSON body')
+      }
+    }
+
+    createMixSchema.parse(body)
+
+    const session = nodelink.sessions.get(sessionId)
+    if (!session) {
+      return sendErrorResponse(req, res, 404, 'Session not found')
+    }
+
+    if (!session.players) {
+      return sendErrorResponse(req, res, 500, 'Player manager not initialized')
+    }
+
+    const mixConfig = nodelink.options?.mix ?? { enabled: true, defaultVolume: 0.8, maxLayersMix: 5, autoCleanup: true }
+    
+    if (!mixConfig.enabled) {
+      return sendErrorResponse(req, res, 403, 'Mix feature is disabled')
+    }
+
+    let trackData = body.track
+    if (trackData.encoded) {
+      trackData = decodeTrack(trackData.encoded)
+      if (body.track.userData !== undefined) {
+        trackData.userData = body.track.userData
+      }
+    } else if (trackData.identifier) {
+      trackData = {
+        identifier: trackData.identifier,
+        userData: body.track.userData
+      }
+    } else {
+      return sendErrorResponse(
+        req, res,
+        400,
+        'Track must have either encoded or identifier'
+      )
+    }
+
+    const result = await session.players.addMix(
+      guildId,
+      trackData,
+      body.volume
+    )
+
+    logger(
+      'debug',
+      'MixAPI',
+      `Created mix ${result.id} for guild ${guildId}`
+    )
+
+    return sendResponse(req, res, {
+      id: result.id,
+      track: result.track,
+      volume: result.volume
+    }, 201)
+  } catch (error) {
+    if (error instanceof myzod.ValidationError) {
+      return sendErrorResponse(req, res, 400, error.message)
+    }
+    logger('error', 'MixAPI', `Error creating mix: ${error.message}`)
+    return sendErrorResponse(req, res, 500, error.message)
+  }
+}
+
+async function handleGetMixes(req, res, sessionId, guildId, nodelink, sendResponse) {
+  try {
+    const session = nodelink.sessions.get(sessionId)
+    if (!session) {
+      return sendErrorResponse(req, res, 404, 'Session not found')
+    }
+
+    if (!session.players) {
+      return sendErrorResponse(req, res, 500, 'Player manager not initialized')
+    }
+
+    const mixes = await session.players.getMixes(guildId)
+
+    return sendResponse(req, res, { mixes }, 200)
+  } catch (error) {
+    logger('error', 'MixAPI', `Error getting mixes: ${error.message}`)
+    return sendErrorResponse(req, res, 500, error.message)
+  }
+}
+
+export default {
+  handler,
+  methods: ['GET', 'POST']
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,7 +23,9 @@ export const GatewayEvents = {
   PLAYER_CREATED: 'PlayerCreatedEvent',
   PLAYER_DESTROYED: 'PlayerDestroyedEvent',
   PLAYER_RECONNECTING: 'PlayerReconnectingEvent',
-  PLAYER_CONNECTED: 'PlayerConnectedEvent'
+  PLAYER_CONNECTED: 'PlayerConnectedEvent',
+  MIX_STARTED: 'MixStartedEvent',
+  MIX_ENDED: 'MixEndedEvent'
 }
 export const EndReasons = {
   STOPPED: 'stopped',

--- a/src/managers/playerManager.js
+++ b/src/managers/playerManager.js
@@ -329,4 +329,116 @@ export default class PlayerManager {
     if (!player) throw new Error('Player not found locally.')
     return player.toJSON()
   }
+
+  async addMix(guildId, trackPayload, volume = null) {
+    const session = this.nodelink.sessions.get(this.sessionId)
+    const playerKey = `${this.sessionId}:${guildId}`
+
+    if (this.isCluster) {
+      const worker = this.nodelink.workerManager.getWorkerForGuild(playerKey)
+      if (!worker) throw new Error('Player not assigned to a worker.')
+      const result = await this.nodelink.workerManager.execute(
+        worker,
+        'playerCommand',
+        {
+          sessionId: this.sessionId,
+          guildId,
+          userId: session.userId,
+          command: 'addMix',
+          args: [trackPayload, volume]
+        }
+      )
+      if (result && result.playerNotFound) {
+        throw new Error('Player not found.')
+      }
+      return result
+    }
+    const player = this.players.get(playerKey)
+    if (!player) throw new Error('Player not found locally.')
+    return player.addMix(trackPayload, volume)
+  }
+
+  async removeMix(guildId, mixId) {
+    const session = this.nodelink.sessions.get(this.sessionId)
+    const playerKey = `${this.sessionId}:${guildId}`
+
+    if (this.isCluster) {
+      const worker = this.nodelink.workerManager.getWorkerForGuild(playerKey)
+      if (!worker) throw new Error('Player not assigned to a worker.')
+      const result = await this.nodelink.workerManager.execute(
+        worker,
+        'playerCommand',
+        {
+          sessionId: this.sessionId,
+          guildId,
+          userId: session.userId,
+          command: 'removeMix',
+          args: [mixId]
+        }
+      )
+      if (result && result.playerNotFound) {
+        throw new Error('Player not found.')
+      }
+      return result
+    }
+    const player = this.players.get(playerKey)
+    if (!player) throw new Error('Player not found locally.')
+    return player.removeMix(mixId)
+  }
+
+  async updateMix(guildId, mixId, volume) {
+    const session = this.nodelink.sessions.get(this.sessionId)
+    const playerKey = `${this.sessionId}:${guildId}`
+
+    if (this.isCluster) {
+      const worker = this.nodelink.workerManager.getWorkerForGuild(playerKey)
+      if (!worker) throw new Error('Player not assigned to a worker.')
+      const result = await this.nodelink.workerManager.execute(
+        worker,
+        'playerCommand',
+        {
+          sessionId: this.sessionId,
+          guildId,
+          userId: session.userId,
+          command: 'updateMix',
+          args: [mixId, volume]
+        }
+      )
+      if (result && result.playerNotFound) {
+        throw new Error('Player not found.')
+      }
+      return result
+    }
+    const player = this.players.get(playerKey)
+    if (!player) throw new Error('Player not found locally.')
+    return player.updateMix(mixId, volume)
+  }
+
+  async getMixes(guildId) {
+    const session = this.nodelink.sessions.get(this.sessionId)
+    const playerKey = `${this.sessionId}:${guildId}`
+
+    if (this.isCluster) {
+      const worker = this.nodelink.workerManager.getWorkerForGuild(playerKey)
+      if (!worker) throw new Error('Player not assigned to a worker.')
+      const result = await this.nodelink.workerManager.execute(
+        worker,
+        'playerCommand',
+        {
+          sessionId: this.sessionId,
+          guildId,
+          userId: session.userId,
+          command: 'getMixes',
+          args: []
+        }
+      )
+      if (result && result.playerNotFound) {
+        throw new Error('Player not found.')
+      }
+      return result
+    }
+    const player = this.players.get(playerKey)
+    if (!player) throw new Error('Player not found locally.')
+    return player.getMixes()
+  }
 }

--- a/src/playback/AudioMixer.js
+++ b/src/playback/AudioMixer.js
@@ -1,0 +1,213 @@
+import { EventEmitter } from 'node:events'
+import { randomBytes } from 'node:crypto'
+
+
+export class AudioMixer extends EventEmitter {
+  constructor(config = {}) {
+    super()
+    this.mixLayers = new Map()
+    this.maxLayers = config.maxLayersMix || 5
+    this.defaultVolume = config.defaultVolume || 0.8
+    this.autoCleanup = config.autoCleanup !== false
+    this.enabled = config.enabled !== false
+  }
+
+
+  mixBuffers(mainPCM, layersPCM) {
+    if (layersPCM.size === 0 || !this.enabled) {
+      return mainPCM
+    }
+
+
+    const output = Buffer.allocUnsafe(mainPCM.length)
+    
+    for (let i = 0; i < mainPCM.length; i += 2) {
+      let mainSample = mainPCM.readInt16LE(i)
+      
+      for (const layer of layersPCM.values()) {
+        if (i < layer.buffer.length) {
+          const layerSample = layer.buffer.readInt16LE(i)
+          mainSample += Math.floor(layerSample * layer.volume)
+        }
+      }
+      
+      mainSample = Math.max(-32768, Math.min(32767, mainSample))
+      output.writeInt16LE(mainSample, i)
+    }
+    
+    return output
+  }
+
+
+  addLayer(stream, track, volume = null) {
+    if (this.mixLayers.size >= this.maxLayers) {
+      throw new Error(`Maximum mix layers (${this.maxLayers}) reached`)
+    }
+
+
+    const id = randomBytes(8).toString('hex')
+    const actualVolume = volume !== null ? volume : this.defaultVolume
+
+
+    const layer = {
+      id,
+      stream,
+      track,
+      volume: Math.max(0, Math.min(1, actualVolume)),
+      position: 0,
+      startTime: Date.now(),
+      active: true,
+      currentBuffer: Buffer.alloc(0),
+      receivedBytes: 0,
+      emptyReads: 0
+    }
+
+
+    this.mixLayers.set(id, layer)
+
+
+    stream.on('data', (chunk) => {
+      if (layer.active) {
+        layer.receivedBytes += chunk.length
+        layer.currentBuffer = Buffer.concat([layer.currentBuffer, chunk])
+        layer.emptyReads = 0
+      }
+    })
+
+
+    stream.once('error', (error) => {
+      this.emit('mixError', { id, error })
+      this.removeLayer(id, 'ERROR')
+    })
+
+
+    this.emit('mixStarted', {
+      id,
+      track,
+      volume: layer.volume
+    })
+
+
+    return id
+  }
+
+
+  readLayerChunks(chunkSize) {
+    const layerChunks = new Map()
+
+
+    for (const [id, layer] of this.mixLayers.entries()) {
+      if (layer.currentBuffer.length === 0) {
+        layer.emptyReads++
+        
+        if (layer.emptyReads >= 3 && layer.receivedBytes > 0) {
+          this.removeLayer(id, 'FINISHED')
+        }
+        continue
+      }
+
+
+      if (!layer.active) {
+        continue
+      }
+
+
+      const readSize = Math.min(chunkSize, layer.currentBuffer.length)
+      const chunk = layer.currentBuffer.subarray(0, readSize)
+      layer.currentBuffer = layer.currentBuffer.subarray(readSize)
+      layer.emptyReads = 0
+      
+      layerChunks.set(id, {
+        buffer: chunk,
+        volume: layer.volume
+      })
+
+
+      layer.position += readSize
+    }
+
+
+    return layerChunks
+  }
+
+
+  hasActiveLayers() {
+    return this.mixLayers.size > 0
+  }
+
+
+  removeLayer(id, reason = 'REMOVED') {
+    const layer = this.mixLayers.get(id)
+    if (!layer) {
+      return false
+    }
+
+
+    layer.active = false
+    
+    if (layer.stream && !layer.stream.destroyed) {
+      layer.stream.destroy()
+    }
+
+
+    this.mixLayers.delete(id)
+
+
+    this.emit('mixEnded', { id, reason })
+
+
+    return true
+  }
+
+
+  updateLayerVolume(id, volume) {
+    const layer = this.mixLayers.get(id)
+    if (!layer) {
+      return false
+    }
+
+
+    layer.volume = Math.max(0, Math.min(1, volume))
+    return true
+  }
+
+
+  getLayer(id) {
+    const layer = this.mixLayers.get(id)
+    if (!layer) {
+      return null
+    }
+
+
+    return {
+      id: layer.id,
+      track: layer.track,
+      volume: layer.volume,
+      position: layer.position,
+      startTime: layer.startTime
+    }
+  }
+
+
+  getLayers() {
+    return Array.from(this.mixLayers.values()).map(layer => ({
+      id: layer.id,
+      track: layer.track,
+      volume: layer.volume,
+      position: layer.position,
+      startTime: layer.startTime
+    }))
+  }
+
+
+  clearLayers(reason = 'CLEARED') {
+    const ids = Array.from(this.mixLayers.keys())
+    
+    for (const id of ids) {
+      this.removeLayer(id, reason)
+    }
+
+
+    return ids.length
+  }
+}

--- a/src/playback/player.js
+++ b/src/playback/player.js
@@ -40,6 +40,8 @@ export class Player {
     this.voice = { sessionId: null, token: null, endpoint: null }
     this.streamInfo = null
     this.lastManualReconnect = 0
+    this.audioMixer = null
+    this._initAudioMixer()
 
     logger(
       'debug',
@@ -94,6 +96,30 @@ export class Player {
     this.destroying = false
     this.isUpdatingTrack = false
     this._initConnection()
+  }
+
+  async _initAudioMixer() {
+    const { AudioMixer } = await import('./AudioMixer.js')
+    this.audioMixer = new AudioMixer(this.nodelink.options?.mix ?? { enabled: true, defaultVolume: 0.8, maxLayersMix: 5, autoCleanup: true })
+    
+    this.audioMixer.on('mixStarted', (data) => {
+      this.emitEvent(GatewayEvents.MIX_STARTED, {
+        mixId: data.id,
+        track: data.track,
+        volume: data.volume
+      })
+    })
+    
+    this.audioMixer.on('mixEnded', (data) => {
+      this.emitEvent(GatewayEvents.MIX_ENDED, {
+        mixId: data.id,
+        reason: data.reason
+      })
+    })
+    
+    this.audioMixer.on('mixError', (data) => {
+      logger('error', 'Player', `Mix error for ${data.id}: ${data.error.message}`)
+    })
   }
 
   _initConnection() {
@@ -333,6 +359,10 @@ export class Player {
       track: trackToEmit,
       reason: reason
     })
+    
+    if (this.audioMixer && this.audioMixer.autoCleanup) {
+      this.audioMixer.clearLayers('MAIN_ENDED')
+    }
   }
 
   async _resolveTrackForEvent(track) {
@@ -388,7 +418,8 @@ export class Player {
       fetched.type || urlData.format,
       this.nodelink,
       this.filters,
-      this.volumePercent / 100
+      this.volumePercent / 100,
+      this.audioMixer
     )
     return { stream: resource }
   }
@@ -794,7 +825,8 @@ export class Player {
         this.nodelink,
         this.filters,
         this,
-        this.volumePercent / 100
+        this.volumePercent / 100,
+        this.audioMixer
       )
 
       if (resourceResult.exception) {
@@ -1137,6 +1169,89 @@ export class Player {
     this._resetTrack()
     this.connStatus = 'destroyed'
     this.volumePercent = this.nodelink.options?.defaultVolume ?? 100
+  }
+
+  async addMix(trackPayload, volume = null) {
+    if (!this.track || this.isPaused) {
+      throw new Error('Cannot add mix without an active stream')
+    }
+
+    if (!this.audioMixer) {
+      throw new Error('AudioMixer not initialized')
+    }
+
+    const mixConfig = this.nodelink?.options?.mix ?? { 
+      enabled: true, 
+      defaultVolume: 0.8, 
+      maxLayersMix: 5 
+    }
+
+    if (this.audioMixer.mixLayers.size >= mixConfig.maxLayersMix) {
+      throw new Error(`Maximum number of mix layers (${mixConfig.maxLayersMix}) reached`)
+    }
+
+    const mixVolume = volume ?? mixConfig.defaultVolume
+
+    const { createAudioResource: createResource } = await import('./streamProcessor.js')
+
+    const urlData = await this.nodelink.sources.getTrackUrl(trackPayload.info)
+    if (!urlData || !urlData.url) {
+      throw new Error('Failed to get stream URL for mix track')
+    }
+
+    const fetched = await this.nodelink.sources.getTrackStream(
+      trackPayload.info,
+      urlData.url,
+      urlData.protocol,
+      urlData.additionalData
+    )
+
+    if (fetched.exception) {
+      throw new Error(fetched.exception.message)
+    }
+
+    const pcmResource = createResource(
+      fetched.stream,
+      fetched.type || urlData.format,
+      this.nodelink,
+      {},
+      mixVolume,
+      null,
+      true
+    )
+
+    const mixId = this.audioMixer.addLayer(
+      pcmResource.stream,
+      trackPayload,
+      mixVolume
+    )
+
+    return {
+      id: mixId,
+      track: trackPayload,
+      volume: mixVolume
+    }
+  }
+
+  removeMix(mixId) {
+    if (!this.audioMixer) {
+      return false
+    }
+    return this.audioMixer.removeLayer(mixId)
+  }
+
+  updateMix(mixId, volume) {
+    if (!this.audioMixer) {
+      return false
+    }
+    return this.audioMixer.updateLayerVolume(mixId, volume)
+  }
+
+  getMixes() {
+    if (!this.audioMixer) {
+      return []
+    }
+    return this.audioMixer.getLayers()
   }
 
   toJSON() {

--- a/src/playback/streamProcessor.js
+++ b/src/playback/streamProcessor.js
@@ -1232,8 +1232,30 @@ class FMP4ToAACStream extends Transform {
     callback()
   }
 }
+
+class MixerTransform extends Transform {
+  constructor(audioMixer) {
+    super()
+    this.audioMixer = audioMixer
+  }
+
+  _transform(mainChunk, encoding, callback) {
+    if (!this.audioMixer || !this.audioMixer.enabled || !this.audioMixer.hasActiveLayers()) {
+      return callback(null, mainChunk)
+    }
+
+    try {
+      const layerChunks = this.audioMixer.readLayerChunks(mainChunk.length)
+      const mixed = this.audioMixer.mixBuffers(mainChunk, layerChunks)
+      callback(null, mixed)
+    } catch (error) {
+      callback(null, mainChunk)
+    }
+  }
+}
+
 class StreamAudioResource extends BaseAudioResource {
-  constructor(stream, type, nodelink, initialFilters = {}, volume = 1.0) {
+  constructor(stream, type, nodelink, initialFilters = {}, volume = 1.0, audioMixer = null, returnPCM = false) {
     super()
 
     this._validateInputStream(stream)
@@ -1250,7 +1272,12 @@ class StreamAudioResource extends BaseAudioResource {
       resamplingQuality
     )
 
-    this._createOutputPipeline(pcmStream, nodelink, initialFilters, volume)
+    if (returnPCM) {
+      this._createPCMOutputPipeline(pcmStream, volume)
+    } else {
+      this._createOutputPipeline(pcmStream, nodelink, initialFilters, volume, audioMixer)
+    }
+    
     this._setupEventHandlers(stream)
   }
 
@@ -1326,7 +1353,7 @@ class StreamAudioResource extends BaseAudioResource {
     return stream.pipe(decoder)
   }
 
-  _createOutputPipeline(pcmStream, nodelink, initialFilters, volume) {
+  _createOutputPipeline(pcmStream, nodelink, initialFilters, volume, audioMixer = null) {
     const volumeTransformer = new VolumeTransformer({ type: 's16le', volume })
     const filters = new FiltersManager(nodelink, initialFilters)
     const opusEncoder = new OpusEncoder({
@@ -1335,10 +1362,29 @@ class StreamAudioResource extends BaseAudioResource {
       frameSize: AUDIO_CONFIG.frameSize
     })
 
-    pcmStream.pipe(volumeTransformer).pipe(filters).pipe(opusEncoder)
+    let pipeline = pcmStream.pipe(volumeTransformer)
+
+    if (audioMixer && (nodelink.options?.mix?.enabled ?? true)) {
+      const mixer = new MixerTransform(audioMixer)
+      pipeline = pipeline.pipe(mixer)
+      this.pipes.push(mixer)
+    }
+
+    pipeline.pipe(filters).pipe(opusEncoder)
 
     this.pipes.push(volumeTransformer, filters, opusEncoder)
     this.stream = opusEncoder
+  }
+
+  _createPCMOutputPipeline(pcmStream, volume) {
+    if (volume !== 1.0) {
+      const volumeTransformer = new VolumeTransformer({ type: 's16le', volume })
+      const outputStream = pcmStream.pipe(volumeTransformer)
+      this.pipes.push(volumeTransformer)
+      this.stream = outputStream
+    } else {
+      this.stream = pcmStream
+    }
   }
 
   _setupEventHandlers(inputStream) {
@@ -1381,8 +1427,8 @@ class StreamAudioResource extends BaseAudioResource {
   }
 }
 
-export const createAudioResource = (stream, type, nodelink, initialFilters = {}, volume = 1.0) =>
-  new StreamAudioResource(stream, type, nodelink, initialFilters, volume)
+export const createAudioResource = (stream, type, nodelink, initialFilters = {}, volume = 1.0, audioMixer = null, returnPCM = false) =>
+  new StreamAudioResource(stream, type, nodelink, initialFilters, volume, audioMixer, returnPCM)
 
 export const createSeekeableAudioResource = async (
   url,
@@ -1391,7 +1437,8 @@ export const createSeekeableAudioResource = async (
   nodelink,
   initialFilters,
   player,
-  volume = 1.0
+  volume = 1.0,
+  audioMixer = null
 ) => {
   try {
     const { stream, meta } = await seekableStream(url, seekTime, endTime, {})
@@ -1412,10 +1459,39 @@ export const createSeekeableAudioResource = async (
       format,
       nodelink,
       initialFilters,
-      volume
+      volume,
+      audioMixer
     )
   } catch (err) {
     const cause = err instanceof SeekError ? err.code : 'UNKNOWN'
     return _createErrorResponse(err.message, cause)
   }
+}
+
+export const createPCMStream = (stream, type, nodelink, volume = 1.0) => {
+  const resamplingQuality = nodelink.options.audio.resamplingQuality || 'fastest'
+  const normalizedType = normalizeFormat(type)
+  
+  const resource = new StreamAudioResource.__proto__.constructor.call({
+    pipes: [stream],
+    _createDecoderPipeline: StreamAudioResource.prototype._createDecoderPipeline,
+    _createSymphoniaPipeline: StreamAudioResource.prototype._createSymphoniaPipeline,
+    _createOpusPipeline: StreamAudioResource.prototype._createOpusPipeline,
+    _createAACPipeline: StreamAudioResource.prototype._createAACPipeline
+  })
+  
+  const pcmStream = resource._createDecoderPipeline.call(
+    { pipes: [] },
+    stream,
+    type,
+    normalizedType,
+    resamplingQuality
+  )
+  
+  if (volume !== 1.0) {
+    const volumeTransformer = new VolumeTransformer({ type: 's16le', volume })
+    return pcmStream.pipe(volumeTransformer)
+  }
+  
+  return pcmStream
 }


### PR DESCRIPTION
## Changes

- Added full audio mixing system with dynamic layer management.
- Introduced new REST endpoints:
  - `POST /sessions/{sessionId}/players/{guildId}/mix` – create a new mix layer.
  - `GET /sessions/{sessionId}/players/{guildId}/mix` – list all mix layers.
  - `PATCH /sessions/{sessionId}/players/{guildId}/mix/{mixId}` – update mix volume.
  - `DELETE /sessions/{sessionId}/players/{guildId}/mix/{mixId}` – remove a mix layer.
- Implemented `AudioMixer` class with:
  - Independent PCM mixing per layer
  - Volume scaling
  - Automatic layer cleanup
  - Finish detection via empty reads
  - Error handling and emissions (`mixStarted`, `mixEnded`, `mixError`)
- Added mix configuration under `mix { enabled, defaultVolume, maxLayersMix, autoCleanup }`.
- Added cluster-aware mix command handling through `playerManager`.
- Player now initializes AudioMixer and emits gateway events:
  - `MixStartedEvent`
  - `MixEndedEvent`
- Mixing is now integrated into playback pipeline through `streamProcessor`.
- Added version bump to `3.3.0`.

## Why

This adds native support for layered audio playback — allowing bots to play sound effects, transitions, stingers, background loops and dynamic overlays **at the same time as the main track**.  
The system is fully dynamic, cluster-safe, and supports real-time volume adjustments and automatic cleanup.

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with Lavalink clients.

## Additional information

- Mixing is done at PCM level for maximum performance.
- Layer streaming is non-blocking and isolated.
- Default config allows 5 simultaneous layers, adjustable via `config.default.js`.
