### PR TITLE
update: readme to mark (TS) Lavalink-Client V3 Supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ However, some clients may not work properly, since NodeLink changes certain beha
 | [Magmastream](https://github.com/Blackfort-Hosting/magmastream)     | TypeScript   | unknown       | No                 | v1                     |
 | [Lavacord](https://github.com/lavacord/Lavacord)                    | TypeScript   | unknown       | No                 | v1 and v2              |
 | [Shoukaku](https://github.com/Deivu/Shoukaku)                       | TypeScript   | unknown       | No                 | v1 and v2              |
-| [Lavalink-Client](https://github.com/tomato6966/Lavalink-Client)    | TypeScript   | unknown       | No                 | v1                     |
+| [Lavalink-Client](https://github.com/tomato6966/Lavalink-Client)    | TypeScript   | Yes           | No                 | v1 and v3              |
 | [Rainlink](https://github.com/RainyXeon/Rainlink)                   | TypeScript   | unknown       | No                 | v1 and v2              |
 | [Poru](https://github.com/parasop/Poru)                             | TypeScript   | unknown       | No                 | v1 and v2              |
 | [Blue.ts](https://github.com/ftrapture/blue.ts)                     | TypeScript   | unknown       | No                 | v1 and v2              |


### PR DESCRIPTION
## Changes

Marks [(TS) Lavalink-Client](https://github.com/Tomato6966/lavalink-client) as V3 Supported.

## Why 

As the client supports baseline features of NodeLink, allowing NodeLink-specific events to be emitted, `detailedStats` from the `stats`, and `isNodeLink` from `/info` endpoint to the User.

## Checkmarks

- [ ] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information

None (❌)!