### PR TITLE
add: system plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 
 !.github
 !.github/**
+!plugins/**
+!plugins
 !docs
 !docs/**
 !src
@@ -20,4 +22,3 @@
 !commitlint.config.mjs
 !.gitmessage
 !docker-compose.yml
-!plugins/**

--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@
 !commitlint.config.mjs
 !.gitmessage
 !docker-compose.yml
-!ytmusic_videodata_1765292622656.json
+!plugins/**

--- a/config.default.js
+++ b/config.default.js
@@ -280,5 +280,12 @@ export default {
     defaultVolume: 0.8,
     maxLayersMix: 5,
     autoCleanup: true
-  }
+  },
+  plugins: [
+    {
+      name: 'nodelink-sample-plugin',
+      source: 'local'
+    }
+  ],
+  pluginConfig: {}
 }

--- a/plugins/@1lucas1apk/tunnel-cloudflared/index.js
+++ b/plugins/@1lucas1apk/tunnel-cloudflared/index.js
@@ -1,0 +1,47 @@
+import fs from "node:fs"
+import { spawn } from "node:child_process"
+
+export default async function(nodelink, config, context) {
+  if (context.type !== 'master') return
+
+  const logger = (msg, level = 'info') => nodelink.logger(level, 'Cloudflared', msg)
+
+  const token = config.token || process.env.CF_TUNNEL_TOKEN
+  const port = nodelink.options.server.port || 3000
+
+  if (!token) {
+    logger('CF_TUNNEL_TOKEN not found. Plugin disabled.', 'warn')
+    return
+  }
+
+  let cloudflared
+  try {
+    cloudflared = await import("cloudflared")
+  } catch (e) {
+    logger('Package "cloudflared" not found. Please install it in the plugin folder.', 'error')
+    return
+  }
+
+  const { bin, install } = cloudflared
+
+  if (!fs.existsSync(bin)) {
+    logger('Installing cloudflared binary...')
+    await install(bin)
+  }
+
+  const tunnel = spawn(
+    bin,
+    ["tunnel", "run", "--token", token, "--url", `http://127.0.0.1:${port}`],
+    { stdio: "inherit", env: process.env }
+  )
+
+  const stopAll = () => {
+    try { tunnel.kill("SIGTERM") } catch {}
+  }
+
+  process.on("SIGINT", stopAll)
+  process.on("SIGTERM", stopAll)
+  process.on("beforeExit", stopAll)
+
+  logger(`Tunnel started on port ${port}`)
+}

--- a/plugins/@1lucas1apk/tunnel-cloudflared/package.json
+++ b/plugins/@1lucas1apk/tunnel-cloudflared/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@1lucas1apk/tunnel-cloudflared",
+  "version": "1.0.0",
+  "description": "Cloudflare Tunnel integration for NodeLink",
+  "type": "module",
+  "main": "index.js",
+  "author": "1lucas1apk",
+  "license": "MIT",
+  "dependencies": {
+    "cloudflared": "^0.7.1"
+  }
+}

--- a/plugins/nodelink-sample-plugin/index.js
+++ b/plugins/nodelink-sample-plugin/index.js
@@ -1,9 +1,9 @@
 /**
  * NodeLink Plugin Entry Point
- * 
+ *
  * This file demonstrates the structure and capabilities of a NodeLink plugin.
  * Plugins are loaded in both the Master process and Worker processes.
- * 
+ *
  * @param {import('../../src/index').NodelinkServer} nodelink - The main server instance.
  * @param {Object} config - The specific configuration for this plugin defined in 'pluginConfig' within config.js.
  * @param {Object} context - Metadata about the execution environment.
@@ -29,11 +29,64 @@ export default async function(nodelink, config, context) {
       }, 200);
     });
 
+    // Test helper: create a test player in a worker (uses mock session inside worker)
+    nodelink.registerRoute('POST', '/v4/sample/create-test-player', async (nodelink, req, res, sendResponse) => {
+      try {
+        const body = req.body || {}
+        const sessionId = body.sessionId || 'test-session'
+        const guildId = body.guildId || '11111111111111111'
+        const voice = body.voice || null
+        const payload = { sessionId, guildId, userId: body.userId || 'test-user', voice }
+        const worker = nodelink.workerManager.getBestWorker()
+        if (!worker) return sendResponse(req, res, { error: 'No worker available' }, 500)
+        const result = await nodelink.workerManager.execute(worker, 'createPlayer', payload)
+        sendResponse(req, res, { result }, 200)
+      } catch (e) {
+        sendResponse(req, res, { error: e.message }, 500)
+      }
+    })
+
+    // Test helper: attempt to load a mysource track and play it on a test player
+    nodelink.registerRoute('POST', '/v4/sample/play-mysource', async (nodelink, req, res, sendResponse) => {
+      try {
+        const body = req.body || {}
+        const sessionId = body.sessionId || 'test-session'
+        const guildId = body.guildId || '11111111111111111'
+        const worker = nodelink.workerManager.getBestWorker()
+        if (!worker) return sendResponse(req, res, { error: 'No worker available' }, 500)
+
+        // create mock player
+        await nodelink.workerManager.execute(worker, 'createPlayer', { sessionId, guildId, userId: body.userId || 'test-user' })
+
+        // try resolving via mysource
+        const load = await nodelink.workerManager.execute(worker, 'loadTracks', { identifier: 'mysource:dummy' })
+
+        // if empty, return load result (nothing to play)
+        if (!load || load.loadType === 'empty' || (load.data && (!load.data.tracks || load.data.tracks.length === 0))) {
+          return sendResponse(req, res, { load }, 200)
+        }
+
+        const track = load.data.tracks[0]
+
+        // send play command to worker player
+        const playRes = await nodelink.workerManager.execute(worker, 'playerCommand', {
+          sessionId,
+          guildId,
+          command: 'play',
+          args: [{ info: track }]
+        })
+
+        sendResponse(req, res, { load, play: playRes }, 200)
+      } catch (e) {
+        sendResponse(req, res, { error: e.message }, 500)
+      }
+    })
+
     // 2. Intercepting Player Commands (Master Side)
     // This allows you to block or modify play/stop/pause/seek/volume commands before they reach the worker.
     nodelink.registerPlayerInterceptor(async (action, guildId, args) => {
       // logger(`Intercepted player action '${action}' for guild ${guildId}`, 'debug');
-      
+
       if (action === 'play') {
         const track = args[0];
         // Example: Block playing a specific track
@@ -58,18 +111,28 @@ export default async function(nodelink, config, context) {
       constructor(nodelink) {
         this.nodelink = nodelink;
         this.sourceName = 'mysource';
+        this.searchTerms = ['mysource'];
       }
       async search(query) { return { loadType: 'empty', data: {} }; }
       async resolve(url) { return { loadType: 'empty', data: {} }; }
       async getTrackUrl(trackInfo) { return { exception: { message: 'Not implemented', severity: 'fault' } }; }
     }
-    nodelink.registerSource('mysource', new MyCustomSource(nodelink));
+    const mySrc = new MyCustomSource(nodelink);
+    nodelink.registerSource('mysource', mySrc);
+    // Ensure the source can be used via the `source:query` syntax by mapping a search term
+    try {
+      nodelink.sources.searchTermMap.set('mysource', 'mysource')
+    } catch (e) {
+      if (nodelink.sources && nodelink.sources.searchTermMap) {
+        nodelink.sources.searchTermMap.set('mysource', 'mysource')
+      }
+    }
 
     // 2. Registering a Custom Audio Filter
     class SimpleGainFilter {
       constructor() { this.gain = 1.0; }
       update(config) { if (config.simpleGain) this.gain = config.simpleGain; }
-      process(chunk) { return chunk; } 
+      process(chunk) { return chunk; }
     }
     nodelink.registerFilter('simpleGain', new SimpleGainFilter());
 
@@ -87,12 +150,12 @@ export default async function(nodelink, config, context) {
     // This intercepts internal IPC commands sent from Master to Worker.
     nodelink.registerWorkerInterceptor(async (type, payload) => {
       // logger(`Worker received command: ${type}`, 'debug');
-      
+
       if (type === 'destroyPlayer') {
         // Example: Log before destroying
         // logger(`Destroying player for guild ${payload.guildId} in worker...`, 'debug');
       }
-      
+
       return false; // Return true to block the command
     });
   }

--- a/plugins/nodelink-sample-plugin/index.js
+++ b/plugins/nodelink-sample-plugin/index.js
@@ -1,0 +1,99 @@
+/**
+ * NodeLink Plugin Entry Point
+ * 
+ * This file demonstrates the structure and capabilities of a NodeLink plugin.
+ * Plugins are loaded in both the Master process and Worker processes.
+ * 
+ * @param {import('../../src/index').NodelinkServer} nodelink - The main server instance.
+ * @param {Object} config - The specific configuration for this plugin defined in 'pluginConfig' within config.js.
+ * @param {Object} context - Metadata about the execution environment.
+ */
+export default async function(nodelink, config, context) {
+  const logger = (msg, level = 'info') => nodelink.logger(level, `Plugin:${context.pluginName}`, msg);
+
+  logger(`Initializing in ${context.type.toUpperCase()} mode.`);
+
+  // =================================================================================
+  // CONTEXT: MASTER
+  // Executed only once in the main process.
+  // =================================================================================
+  if (context.type === 'master') {
+    logger('Running Master setup...');
+
+    // 1. Registering a Custom API Route
+    nodelink.registerRoute('GET', '/v4/sample/status', (nodelink, req, res, sendResponse) => {
+      sendResponse(req, res, {
+        status: 'ok',
+        message: 'Hello from NodeLink Sample Plugin!',
+        version: context.meta.version
+      }, 200);
+    });
+
+    // 2. Intercepting Player Commands (Master Side)
+    // This allows you to block or modify play/stop/pause/seek/volume commands before they reach the worker.
+    nodelink.registerPlayerInterceptor(async (action, guildId, args) => {
+      // logger(`Intercepted player action '${action}' for guild ${guildId}`, 'debug');
+      
+      if (action === 'play') {
+        const track = args[0];
+        // Example: Block playing a specific track
+        if (track?.info?.title?.includes('Forbidden Song')) {
+          logger(`Blocked playback of forbidden song for guild ${guildId}`, 'warn');
+          return { error: 'This song is forbidden by plugin.' }; // Returns this to the caller immediately
+        }
+      }
+      return null; // Continue execution
+    });
+  }
+
+  // =================================================================================
+  // CONTEXT: WORKER
+  // Executed in every worker process (if cluster is enabled).
+  // =================================================================================
+  if (context.type === 'worker') {
+    logger('Running Worker setup...');
+
+    // 1. Registering a Custom Audio Source
+    class MyCustomSource {
+      constructor(nodelink) {
+        this.nodelink = nodelink;
+        this.sourceName = 'mysource';
+      }
+      async search(query) { return { loadType: 'empty', data: {} }; }
+      async resolve(url) { return { loadType: 'empty', data: {} }; }
+      async getTrackUrl(trackInfo) { return { exception: { message: 'Not implemented', severity: 'fault' } }; }
+    }
+    nodelink.registerSource('mysource', new MyCustomSource(nodelink));
+
+    // 2. Registering a Custom Audio Filter
+    class SimpleGainFilter {
+      constructor() { this.gain = 1.0; }
+      update(config) { if (config.simpleGain) this.gain = config.simpleGain; }
+      process(chunk) { return chunk; } 
+    }
+    nodelink.registerFilter('simpleGain', new SimpleGainFilter());
+
+    // 3. Registering an Audio Interceptor (Low Level)
+    const { Transform } = await import('node:stream');
+    nodelink.registerAudioInterceptor(() => {
+      return new Transform({
+        transform(chunk, encoding, callback) {
+          callback(null, chunk);
+        }
+      });
+    });
+
+    // 4. Intercepting Worker Commands (Worker Side)
+    // This intercepts internal IPC commands sent from Master to Worker.
+    nodelink.registerWorkerInterceptor(async (type, payload) => {
+      // logger(`Worker received command: ${type}`, 'debug');
+      
+      if (type === 'destroyPlayer') {
+        // Example: Log before destroying
+        // logger(`Destroying player for guild ${payload.guildId} in worker...`, 'debug');
+      }
+      
+      return false; // Return true to block the command
+    });
+  }
+}

--- a/plugins/nodelink-sample-plugin/package.json
+++ b/plugins/nodelink-sample-plugin/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "nodelink-sample-plugin",
+  "version": "1.0.0",
+  "description": "A sample plugin demonstrating the NodeLink Plugin API capabilities",
+  "type": "module",
+  "main": "index.js",
+  "author": "NodeLink Team",
+  "license": "MIT"
+}

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -62,6 +62,15 @@ const routesPromise = loadRoutes()
 async function requestHandler(nodelink, req, res) {
   const startTime = Date.now()
   const parsedUrl = new URL(req.url, `http://${req.headers.host}`)
+
+  const middlewares = nodelink.extensions?.middlewares
+  if (middlewares && Array.isArray(middlewares)) {
+    for (const middleware of middlewares) {
+      const result = await middleware(nodelink, req, res, parsedUrl)
+      if (result === true) return // Middleware handled the response
+    }
+  }
+
   nodelink.statsManager.incrementApiRequest(parsedUrl.pathname)
   const trace = parsedUrl.searchParams.get('trace') === 'true'
   const remoteAddress = req.socket.remoteAddress
@@ -257,6 +266,30 @@ async function requestHandler(nodelink, req, res) {
       return
     staticRoute.handler(nodelink, req, res, sendResponse, parsedUrl)
     return
+  }
+
+  const customRoutes = nodelink.extensions?.routes
+  if (customRoutes && Array.isArray(customRoutes)) {
+    const customRoute = customRoutes.find(
+      (r) => r.path === parsedUrl.pathname
+    )
+
+    if (customRoute) {
+      if (
+        !verifyMethod(
+          parsedUrl,
+          req,
+          res,
+          customRoute.method ? [customRoute.method] : ['GET'],
+          clientAddress,
+          trace
+        )
+      )
+        return
+
+      customRoute.handler(nodelink, req, res, sendResponse, parsedUrl)
+      return
+    }
   }
 
   for (const [regex, route] of dynamicRoutes) {

--- a/src/api/info.js
+++ b/src/api/info.js
@@ -27,7 +27,14 @@ async function handler(nodelink, req, res, sendResponse) {
         ? Array.from(nodelink.sources.sources.keys())
         : [],
     filters,
-    plugins: []
+    plugins: nodelink.pluginManager
+      ? Array.from(nodelink.pluginManager.loadedPlugins.values()).map((p) => ({
+          name: p.name,
+          version: p.meta?.version || '0.0.0',
+          author: p.meta?.author || null,
+          path: p.path || null
+        }))
+      : []
   }
   sendResponse(req, res, response, 200)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ import { GatewayEvents } from './constants.js'
 import DosProtectionManager from './managers/dosProtectionManager.js'
 import PlayerManager from './managers/playerManager.js'
 import RateLimitManager from './managers/rateLimitManager.js'
+import PluginManager from './managers/pluginManager.js'
 
 let config
 
@@ -119,6 +120,7 @@ class NodelinkServer {
     if (!options || Object.keys(options).length === 0)
       throw new Error('Configuration file not found or empty')
     this.options = options
+    this.logger = logger
     this.server = null
     this.socket = null
     this.sessions = new sessionManager(this, PlayerManagerClass)
@@ -134,12 +136,25 @@ class NodelinkServer {
     this.statsManager = new statsManager(this)
     this.rateLimitManager = new RateLimitManager(this)
     this.dosProtectionManager = new DosProtectionManager(this)
+    this.pluginManager = new PluginManager(this)
     this.version = getVersion()
     this.gitInfo = getGitInfo()
     this.statistics = {
       players: 0,
       playingPlayers: 0
     }
+    
+    this.extensions = {
+      sources: new Map(),
+      filters: new Map(),
+      routes: [],
+      middlewares: [],
+      trackModifiers: [],
+      wsInterceptors: [],
+      audioInterceptors: [],
+      playerInterceptors: []
+    }
+    
     this._globalUpdater = null
     this.supportedSourcesCache = null
 
@@ -193,6 +208,30 @@ class NodelinkServer {
     this.socket.on(
       '/v4/websocket',
       (socket, request, clientInfo, oldSessionId) => {
+        const originalOn = socket.on.bind(socket)
+        socket.on = (event, listener) => {
+          if (event === 'message') {
+            return originalOn(event, async (data) => {
+              const interceptors = this.extensions?.wsInterceptors
+              if (interceptors && Array.isArray(interceptors)) {
+                let parsedData
+                try {
+                  parsedData = JSON.parse(data.toString())
+                } catch {
+                  parsedData = data
+                }
+
+                for (const interceptor of interceptors) {
+                  const handled = await interceptor(this, socket, parsedData, clientInfo)
+                  if (handled === true) return
+                }
+              }
+              listener(data)
+            })
+          }
+          return originalOn(event, listener)
+        }
+
         logger(
           'debug',
           'Resume',
@@ -779,6 +818,11 @@ class NodelinkServer {
     this._validateConfig()
 
     await this.statsManager.initialize()
+    await this.pluginManager.load('master')
+    
+    if (!startOptions.isClusterPrimary) {
+      await this.pluginManager.load('worker')
+    }
 
     if (this.options.sources.youtube?.getOAuthToken) {
       logger(
@@ -874,6 +918,51 @@ class NodelinkServer {
       const sessionCount = this.sessions.activeSessions?.size || 0
       this.statsManager.setWebsocketConnections(sessionCount)
     }, updateInterval)
+  }
+
+  registerSource(name, source) {
+    if (!this.sources) {
+      logger('warn', 'Server', 'Cannot register source in this context (sources manager not available).')
+      return
+    }
+    this.sources.sources.set(name, source)
+    logger('info', 'Server', `Registered custom source: ${name}`)
+  }
+
+  registerFilter(name, filter) {
+    this.extensions.filters.set(name, filter)
+    logger('info', 'Server', `Registered custom filter: ${name}`)
+  }
+
+  registerRoute(method, path, handler) {
+    this.extensions.routes.push({ method, path, handler })
+    logger('info', 'Server', `Registered custom route: ${method} ${path}`)
+  }
+
+  registerMiddleware(fn) {
+    this.extensions.middlewares.push(fn)
+    logger('info', 'Server', 'Registered custom REST interceptor (middleware)')
+  }
+
+  registerTrackModifier(fn) {
+    this.extensions.trackModifiers.push(fn)
+    logger('info', 'Server', 'Registered custom track info modifier')
+  }
+
+  registerWebSocketInterceptor(fn) {
+    this.extensions.wsInterceptors.push(fn)
+    logger('info', 'Server', 'Registered custom WebSocket interceptor')
+  }
+
+  registerAudioInterceptor(interceptor) {
+    if (!this.extensions.audioInterceptors) this.extensions.audioInterceptors = []
+    this.extensions.audioInterceptors.push(interceptor)
+    logger('info', 'Server', 'Registered custom audio interceptor')
+  }
+
+  registerPlayerInterceptor(interceptor) {
+    this.extensions.playerInterceptors.push(interceptor)
+    logger('info', 'Server', 'Registered custom player interceptor')
   }
 }
 

--- a/src/managers/playerManager.js
+++ b/src/managers/playerManager.js
@@ -8,6 +8,23 @@ export default class PlayerManager {
     this.isCluster = !!nodelink.workerManager
   }
 
+  async _runInterceptors(action, guildId, ...args) {
+    const interceptors = this.nodelink.extensions?.playerInterceptors
+    if (!interceptors || interceptors.length === 0) return null
+
+    for (const interceptor of interceptors) {
+      try {
+        const result = await interceptor(action, guildId, args)
+        if (result !== null && result !== undefined && result !== false) {
+          return { handled: true, result }
+        }
+      } catch (e) {
+        logger('error', 'PlayerManager', `Interceptor error for ${action}: ${e.message}`)
+      }
+    }
+    return null
+  }
+
   async create(guildId, voice) {
     const session = this.nodelink.sessions.get(this.sessionId)
     const playerKey = `${this.sessionId}:${guildId}`
@@ -107,6 +124,9 @@ export default class PlayerManager {
   }
 
   async play(guildId, trackPayload) {
+    const interception = await this._runInterceptors('play', guildId, trackPayload)
+    if (interception?.handled) return interception.result
+
     const session = this.nodelink.sessions.get(this.sessionId)
     const playerKey = `${this.sessionId}:${guildId}`
 
@@ -135,6 +155,9 @@ export default class PlayerManager {
   }
 
   async stop(guildId) {
+    const interception = await this._runInterceptors('stop', guildId)
+    if (interception?.handled) return interception.result
+
     const session = this.nodelink.sessions.get(this.sessionId)
     const playerKey = `${this.sessionId}:${guildId}`
 
@@ -163,6 +186,9 @@ export default class PlayerManager {
   }
 
   async pause(guildId, shouldPause) {
+    const interception = await this._runInterceptors('pause', guildId, shouldPause)
+    if (interception?.handled) return interception.result
+
     const session = this.nodelink.sessions.get(this.sessionId)
     const playerKey = `${this.sessionId}:${guildId}`
 
@@ -191,6 +217,9 @@ export default class PlayerManager {
   }
 
   async seek(guildId, position, endTime) {
+    const interception = await this._runInterceptors('seek', guildId, position, endTime)
+    if (interception?.handled) return interception.result
+
     const session = this.nodelink.sessions.get(this.sessionId)
     const playerKey = `${this.sessionId}:${guildId}`
 
@@ -219,6 +248,9 @@ export default class PlayerManager {
   }
 
   async volume(guildId, level) {
+    const interception = await this._runInterceptors('volume', guildId, level)
+    if (interception?.handled) return interception.result
+
     const session = this.nodelink.sessions.get(this.sessionId)
     const playerKey = `${this.sessionId}:${guildId}`
 
@@ -247,6 +279,9 @@ export default class PlayerManager {
   }
 
   async setFilters(guildId, filtersPayload) {
+    const interception = await this._runInterceptors('setFilters', guildId, filtersPayload)
+    if (interception?.handled) return interception.result
+
     const session = this.nodelink.sessions.get(this.sessionId)
     const playerKey = `${this.sessionId}:${guildId}`
 
@@ -275,6 +310,9 @@ export default class PlayerManager {
   }
 
   async updateVoice(guildId, voicePayload) {
+    const interception = await this._runInterceptors('updateVoice', guildId, voicePayload)
+    if (interception?.handled) return interception.result
+
     const session = this.nodelink.sessions.get(this.sessionId)
     const playerKey = `${this.sessionId}:${guildId}`
 

--- a/src/managers/pluginManager.js
+++ b/src/managers/pluginManager.js
@@ -1,0 +1,166 @@
+import fs from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { logger } from '../utils.js'
+
+const require = createRequire(import.meta.url)
+
+export default class PluginManager {
+  constructor(nodelink) {
+    this.nodelink = nodelink
+    this.config = nodelink.options.plugins || []
+    this.pluginConfigs = nodelink.options.pluginConfig || {}
+    this.pluginsDir = path.join(process.cwd(), 'plugins')
+    this.loadedPlugins = new Map()
+  }
+
+  async load(contextType) {
+    logger('info', 'PluginManager', `Initializing plugins in ${contextType} context...`)
+
+    try {
+      await fs.access(this.pluginsDir)
+    } catch {
+      await fs.mkdir(this.pluginsDir, { recursive: true })
+    }
+
+    if (Array.isArray(this.config)) {
+      for (const pluginDef of this.config) {
+        await this._loadPlugin(pluginDef, contextType)
+      }
+    }
+
+    logger('info', 'PluginManager', `Plugins processed for ${contextType}.`)
+  }
+
+  async _findPackageJson(startPath) {
+    let currentDir = path.dirname(startPath)
+    
+    while (currentDir !== path.parse(currentDir).root) {
+      const pkgPath = path.join(currentDir, 'package.json')
+      try {
+        await fs.access(pkgPath)
+        const data = await fs.readFile(pkgPath, 'utf-8')
+        return JSON.parse(data)
+      } catch {
+        if (path.basename(currentDir) === 'node_modules') break
+        currentDir = path.dirname(currentDir)
+      }
+    }
+    return null
+  }
+
+  async _loadPlugin(def, contextType) {
+    const { name, source, path: localPath, package: packageName } = def
+
+    if (!name) return
+
+    if (this.loadedPlugins.has(name)) {
+      const cached = this.loadedPlugins.get(name)
+      await this._executePlugin(cached.module, name, contextType, cached.meta)
+      return
+    }
+
+    try {
+      let entryPoint = null
+      let pluginMeta = {
+        name,
+        version: '0.0.0',
+        author: 'Unknown',
+        topic: null
+      }
+
+      if (source === 'local') {
+        const resolvedPath = path.resolve(this.pluginsDir, localPath || name)
+        const stat = await fs.stat(resolvedPath)
+        
+        if (stat.isDirectory()) {
+          const pkgPath = path.join(resolvedPath, 'package.json')
+          try {
+            const pkgData = await fs.readFile(pkgPath, 'utf-8')
+            const pkg = JSON.parse(pkgData)
+            
+            if (pkg.version) pluginMeta.version = pkg.version
+            if (pkg.author) pluginMeta.author = typeof pkg.author === 'object' ? pkg.author.name : pkg.author
+            if (pkg.homepage || (pkg.repository && pkg.repository.url)) {
+              pluginMeta.topic = pkg.homepage || pkg.repository.url
+            }
+
+            if (pkg.main) {
+              entryPoint = path.join(resolvedPath, pkg.main)
+            } else {
+              entryPoint = path.join(resolvedPath, 'index.js')
+            }
+          } catch {
+            entryPoint = path.join(resolvedPath, 'index.js')
+          }
+        } else {
+          entryPoint = resolvedPath
+        }
+      } else if (source === 'npm') {
+        try {
+          const pkgName = packageName || name
+          entryPoint = require.resolve(pkgName)
+          
+          const pkg = await this._findPackageJson(entryPoint)
+          if (pkg) {
+            if (pkg.version) pluginMeta.version = pkg.version
+            if (pkg.author) pluginMeta.author = typeof pkg.author === 'object' ? pkg.author.name : pkg.author
+            if (pkg.homepage || (pkg.repository && pkg.repository.url)) {
+              pluginMeta.topic = pkg.homepage || pkg.repository.url
+            }
+          }
+        } catch (e) {
+          logger('warn', 'PluginManager', `NPM package '${packageName || name}' not found.`)
+          return
+        }
+      }
+
+      if (!entryPoint) return
+
+      const fileUrl = pathToFileURL(entryPoint).href
+      const pluginModule = await import(fileUrl)
+
+      if (typeof pluginModule.default !== 'function') {
+        throw new Error(`Plugin '${name}' entry point must export a default function.`)
+      }
+
+      this.loadedPlugins.set(name, {
+        name,
+        path: entryPoint,
+        module: pluginModule,
+        meta: pluginMeta
+      })
+
+      await this._executePlugin(pluginModule, name, contextType, pluginMeta)
+
+      const author = `\x1b[36m${pluginMeta.author}\x1b[0m`
+      const pluginName = `\x1b[1m\x1b[32m${name}\x1b[0m`
+      const version = `\x1b[33mv${pluginMeta.version}\x1b[0m`
+      const topic = pluginMeta.topic ? ` | \x1b[34mTopic:\x1b[0m ${pluginMeta.topic}` : ''
+
+      const creditString = `[${author}] ${pluginName} ${version}${topic}`
+      
+      logger('info', 'PluginManager', `Loaded: ${creditString}`)
+
+    } catch (error) {
+      logger('error', 'PluginManager', `Failed to load plugin '${name}': ${error.message}`)
+    }
+  }
+
+  async _executePlugin(pluginModule, name, contextType, meta) {
+    const specificConfig = this.pluginConfigs[name] || {}
+    const context = {
+      type: contextType,
+      workerId: process.pid,
+      pluginName: name,
+      meta
+    }
+
+    try {
+      await pluginModule.default(this.nodelink, specificConfig, context)
+    } catch (err) {
+      logger('error', 'PluginManager', `Error executing plugin '${name}' in '${contextType}' context: ${err.message}`)
+    }
+  }
+}

--- a/src/playback/filtersManager.js
+++ b/src/playback/filtersManager.js
@@ -41,6 +41,12 @@ export class FiltersManager extends Transform {
       spatial: new Spatial()
     }
 
+    if (this.nodelink.extensions?.filters) {
+      for (const [name, filter] of this.nodelink.extensions.filters) {
+        this.availableFilters[name] = filter
+      }
+    }
+
     this.update(options)
   }
 

--- a/src/playback/streamProcessor.js
+++ b/src/playback/streamProcessor.js
@@ -1394,8 +1394,27 @@ class StreamAudioResource extends BaseAudioResource {
       this.pipes.push(mixer)
     }
 
-    streams.push(filters, opusEncoder)
-    this.pipes.push(filters, opusEncoder)
+    streams.push(filters)
+    this.pipes.push(filters)
+
+    // Inject Audio Interceptors (Low-level stream manipulation)
+    if (nodelink.extensions?.audioInterceptors) {
+      for (const interceptorFactory of nodelink.extensions.audioInterceptors) {
+        try {
+          const interceptorStream = interceptorFactory()
+          if (interceptorStream && typeof interceptorStream.pipe === 'function') {
+            streams.push(interceptorStream)
+            this.pipes.push(interceptorStream)
+          }
+        } catch (e) {
+          // Log error but don't break pipeline
+          console.error(`Audio interceptor error: ${e.message}`)
+        }
+      }
+    }
+
+    streams.push(opusEncoder)
+    this.pipes.push(opusEncoder)
 
     pipeline(streams, (err) => {
       if (err && !this._destroyed) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -227,6 +227,36 @@ function getVersion(type = 'string') {
   }
 }
 
+function modifyPayload(nodelink, data) {
+  if (!data || typeof data !== 'object') return data
+  const modifiers = nodelink.extensions?.trackModifiers
+  if (!modifiers || modifiers.length === 0) return data
+
+  if (Array.isArray(data)) {
+    return data.map((item) => modifyPayload(nodelink, item))
+  }
+
+  const modifiedData = { ...data }
+
+  if (modifiedData.info && modifiedData.encoded !== undefined) {
+    for (const modifier of modifiers) {
+      try {
+        modifier(modifiedData)
+      } catch (e) {
+        logger('error', 'PluginManager', `Track modifier error: ${e.message}`)
+      }
+    }
+  }
+
+  for (const key in modifiedData) {
+    if (typeof modifiedData[key] === 'object' && key !== 'info') {
+      modifiedData[key] = modifyPayload(nodelink, modifiedData[key])
+    }
+  }
+
+  return modifiedData
+}
+
 function sendResponse(req, res, data, status, trace = false) {
   const headers = {}
 
@@ -236,9 +266,11 @@ function sendResponse(req, res, data, status, trace = false) {
     return
   }
 
-  let finalData = data
-  if (data.trace && !trace) {
-    const { trace: _, ...rest } = data
+  const nodelink = global.nodelink
+  let finalData = nodelink ? modifyPayload(nodelink, data) : data
+
+  if (finalData.trace && !trace) {
+    const { trace: _, ...rest } = finalData
     finalData = rest
   }
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -5,6 +5,7 @@ let lastCpuTime = Date.now()
 
 import ConnectionManager from './managers/connectionManager.js'
 import LyricsManager from './managers/lyricsManager.js'
+import PluginManager from './managers/pluginManager.js'
 import RoutePlannerManager from './managers/routePlannerManager.js'
 import SourceManager from './managers/sourceManager.js'
 import StatsManager from './managers/statsManager.js'
@@ -32,11 +33,44 @@ nodelink.sources = new SourceManager(nodelink)
 nodelink.lyrics = new LyricsManager(nodelink)
 nodelink.routePlanner = new RoutePlannerManager(nodelink)
 nodelink.connectionManager = new ConnectionManager(nodelink)
+nodelink.pluginManager = new PluginManager(nodelink)
+
+nodelink.extensions = {
+  workerInterceptors: [],
+  audioInterceptors: []
+}
+
+nodelink.registerWorkerInterceptor = (fn) => {
+  nodelink.extensions.workerInterceptors.push(fn)
+  logger('info', 'Worker', 'Registered worker command interceptor')
+}
+
+nodelink.registerSource = (name, source) => {
+  if (!nodelink.sources) {
+    logger('warn', 'Worker', 'Cannot register source (sources manager not ready).')
+    return
+  }
+  nodelink.sources.sources.set(name, source)
+  logger('info', 'Worker', `Registered custom source: ${name}`)
+}
+
+nodelink.registerFilter = (name, filter) => {
+  if (!nodelink.extensions.filters) nodelink.extensions.filters = new Map()
+  nodelink.extensions.filters.set(name, filter)
+  logger('info', 'Worker', `Registered custom filter: ${name}`)
+}
+
+nodelink.registerAudioInterceptor = (interceptor) => {
+  if (!nodelink.extensions.audioInterceptors) nodelink.extensions.audioInterceptors = []
+  nodelink.extensions.audioInterceptors.push(interceptor)
+  logger('info', 'Worker', 'Registered custom audio interceptor')
+}
 
 async function initialize() {
   await nodelink.sources.loadFolder()
   await nodelink.lyrics.loadFolder()
   await nodelink.statsManager.initialize()
+  await nodelink.pluginManager.load('worker')
   logger(
     'info',
     'Worker',
@@ -77,6 +111,25 @@ async function processQueue() {
   if (commandQueue.length === 0) return
 
   const { type, requestId, payload } = commandQueue.shift()
+
+  // Execute Worker Interceptors
+  const interceptors = nodelink.extensions.workerInterceptors
+  if (interceptors && interceptors.length > 0) {
+    for (const interceptor of interceptors) {
+      try {
+        const shouldBlock = await interceptor(type, payload)
+        if (shouldBlock === true) {
+          if (process.connected && requestId) {
+             process.send({ type: 'commandResult', requestId, payload: { intercepted: true } })
+          }
+          setImmediate(processQueue)
+          return
+        }
+      } catch (e) {
+        logger('error', 'Worker', `Interceptor error: ${e.message}`)
+      }
+    }
+  }
 
   try {
     let result


### PR DESCRIPTION
## Changes

Added the new plugin system and the PluginManager. Plugins can now register custom REST routes, WebSocket interceptors, audio interceptors, middleware, filters, sources and player interceptors. Updated /info to expose plugin metadata. Implemented a working Cloudflare Tunnel plugin and a sample plugin for demonstration. Adjusted the server bootstrap to load plugins in master and worker contexts.

## Why 

This feature makes NodeLink extensible without modifying core files. It enables developers to integrate new behavior cleanly and encourages future contributions. The design keeps compatibility with existing clients while allowing third-party plugins to hook into core events in a controlled way.

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information

The plugin API was designed to be minimal at first but flexible enough for future features, including additional hooks, plugin configuration and validation. The sample plugin serves as practical documentation until formal docs are released.