### PR TITLE
feat: add reverb and flanger audio filters

### DIFF
--- a/src/playback/filters/flanger.js
+++ b/src/playback/filters/flanger.js
@@ -1,0 +1,92 @@
+import { SAMPLE_RATE } from '../../constants.js'
+import { clamp16Bit } from './dsp/clamp16Bit.js'
+import DelayLine from './dsp/delay.js'
+import LFO from './dsp/lfo.js'
+
+const MAX_DELAY_MS = 15
+const bufferSize = Math.ceil((SAMPLE_RATE * MAX_DELAY_MS) / 1000)
+
+export default class Flanger {
+  constructor() {
+    this.priority = 10
+
+    this.delayLeft = new DelayLine(bufferSize)
+    this.delayRight = new DelayLine(bufferSize)
+
+    this.lfoLeft = new LFO('SINE')
+    this.lfoRight = new LFO('SINE')
+    this.lfoRight.phase = Math.PI / 4
+
+    this.rate = 0
+    this.depth = 0
+    this.delay = 5
+    this.feedback = 0
+    this.mix = 0.5
+
+    this.lastLeftOutput = 0
+    this.lastRightOutput = 0
+  }
+
+  update(filters) {
+    const settings = filters.flanger || {}
+
+    this.rate = Math.max(0, Math.min(settings.rate || 0, 10))
+
+    this.depth = Math.max(0, Math.min(settings.depth || 0, 1.0))
+
+    this.delay = Math.max(
+      1,
+      Math.min(settings.delay || 5, MAX_DELAY_MS - 5)
+    )
+
+    this.feedback = Math.max(
+      -0.95,
+      Math.min(settings.feedback || 0, 0.95)
+    )
+
+    this.mix = Math.max(0, Math.min(settings.mix || 0.5, 1.0))
+
+    this.lfoLeft.update(this.rate, this.depth)
+    this.lfoRight.update(this.rate, this.depth)
+  }
+
+  process(chunk) {
+    if (this.rate === 0 || this.depth === 0 || this.mix === 0) {
+      return chunk
+    }
+
+    const baseDelaySamples = (this.delay * SAMPLE_RATE) / 1000
+    const maxModulation = this.depth * (SAMPLE_RATE * 0.003)
+
+    for (let i = 0; i < chunk.length; i += 4) {
+      const leftInput = chunk.readInt16LE(i)
+      const rightInput = chunk.readInt16LE(i + 2)
+
+      const lfoValueLeft = this.lfoLeft.getValue()
+      const lfoValueRight = this.lfoRight.getValue()
+
+      const delayTimeLeft = baseDelaySamples + lfoValueLeft * maxModulation
+      const delayTimeRight = baseDelaySamples + lfoValueRight * maxModulation
+
+      const delayedLeft = this.delayLeft.read(delayTimeLeft)
+      const delayedRight = this.delayRight.read(delayTimeRight)
+
+      const wetLeft = delayedLeft + this.lastLeftOutput * this.feedback
+      const wetRight = delayedRight + this.lastRightOutput * this.feedback
+
+      const outputLeft = leftInput * (1.0 - this.mix) + wetLeft * this.mix
+      const outputRight = rightInput * (1.0 - this.mix) + wetRight * this.mix
+
+      this.lastLeftOutput = wetLeft
+      this.lastRightOutput = wetRight
+
+      this.delayLeft.write(clamp16Bit(leftInput + wetLeft * this.feedback))
+      this.delayRight.write(clamp16Bit(rightInput + wetRight * this.feedback))
+
+      chunk.writeInt16LE(clamp16Bit(outputLeft), i)
+      chunk.writeInt16LE(clamp16Bit(outputRight), i + 2)
+    }
+
+    return chunk
+  }
+}

--- a/src/playback/filters/reverb.js
+++ b/src/playback/filters/reverb.js
@@ -1,0 +1,159 @@
+import { SAMPLE_RATE } from '../../constants.js'
+import { clamp16Bit } from './dsp/clamp16Bit.js'
+import Allpass from './dsp/allpass.js'
+import DelayLine from './dsp/delay.js'
+
+const COMB_DELAYS = [1116, 1188, 1277, 1356, 1422, 1491, 1557, 1617]
+const ALLPASS_DELAYS = [556, 441, 341, 225]
+const STEREO_SPREAD = 23
+const SCALE_WET = 3.0
+const SCALE_DRY = 2.0
+const SCALE_DAMP = 0.4
+const SCALE_ROOM = 0.28
+const OFFSET_ROOM = 0.7
+
+class CombFilter {
+  constructor(size) {
+    this.buffer = new DelayLine(size)
+    this.filterStore = 0
+    this.damp1 = 0
+    this.damp2 = 0
+    this.feedback = 0
+  }
+
+  setDamp(val) {
+    this.damp1 = val
+    this.damp2 = 1 - val
+  }
+
+  setFeedback(val) {
+    this.feedback = val
+  }
+
+  process(input) {
+    const output = this.buffer.read(0)
+    this.filterStore = output * this.damp2 + this.filterStore * this.damp1
+    this.buffer.write(clamp16Bit(input + this.filterStore * this.feedback))
+    return output
+  }
+
+  clear() {
+    this.buffer.clear()
+    this.filterStore = 0
+  }
+}
+
+export default class Reverb {
+  constructor() {
+    this.priority = 10
+
+    this.combFiltersL = COMB_DELAYS.map(
+      (delay) => new CombFilter(Math.floor((delay * SAMPLE_RATE) / 44100))
+    )
+    this.combFiltersR = COMB_DELAYS.map(
+      (delay) =>
+        new CombFilter(
+          Math.floor(((delay + STEREO_SPREAD) * SAMPLE_RATE) / 44100)
+        )
+    )
+
+    this.allpassFiltersL = ALLPASS_DELAYS.map(
+      (delay) => new DelayLine(Math.floor((delay * SAMPLE_RATE) / 44100))
+    )
+    this.allpassFiltersR = ALLPASS_DELAYS.map(
+      (delay) =>
+        new DelayLine(
+          Math.floor(((delay + STEREO_SPREAD) * SAMPLE_RATE) / 44100)
+        )
+    )
+
+    this.allpassCoeff = 0.5
+
+    this.allpassStateL = ALLPASS_DELAYS.map(() => ({ x1: 0, y1: 0 }))
+    this.allpassStateR = ALLPASS_DELAYS.map(() => ({ x1: 0, y1: 0 }))
+
+    this.wet = 0
+    this.dry = 1.0
+    this.roomSize = 0.5
+    this.damping = 0.5
+    this.width = 1.0
+  }
+
+  update(filters) {
+    const settings = filters.reverb || {}
+
+    const mix = Math.max(0, Math.min(settings.mix || 0, 1.0))
+    this.wet = mix * SCALE_WET
+    this.dry = (1.0 - mix) * SCALE_DRY
+
+    this.roomSize = Math.max(0, Math.min(settings.roomSize || 0.5, 1.0))
+    const roomScaled = this.roomSize * SCALE_ROOM + OFFSET_ROOM
+
+    this.damping = Math.max(0, Math.min(settings.damping || 0.5, 1.0))
+    const dampScaled = this.damping * SCALE_DAMP
+
+    this.width = Math.max(0, Math.min(settings.width || 1.0, 1.0))
+
+    for (const comb of [...this.combFiltersL, ...this.combFiltersR]) {
+      comb.setFeedback(roomScaled)
+      comb.setDamp(dampScaled)
+    }
+  }
+
+  process(chunk) {
+    if (this.wet === 0) {
+      return chunk
+    }
+
+    for (let i = 0; i < chunk.length; i += 4) {
+      const leftInput = chunk.readInt16LE(i)
+      const rightInput = chunk.readInt16LE(i + 2)
+
+      const monoInput = (leftInput + rightInput) * 0.5
+
+      let leftOut = 0
+      let rightOut = 0
+
+      for (let j = 0; j < this.combFiltersL.length; j++) {
+        leftOut += this.combFiltersL[j].process(monoInput)
+        rightOut += this.combFiltersR[j].process(monoInput)
+      }
+
+      for (let j = 0; j < this.allpassFiltersL.length; j++) {
+        leftOut = this.processAllpass(
+          leftOut,
+          this.allpassFiltersL[j],
+          this.allpassStateL[j]
+        )
+        rightOut = this.processAllpass(
+          rightOut,
+          this.allpassFiltersR[j],
+          this.allpassStateR[j]
+        )
+      }
+
+      const wet1 = this.wet * (this.width * 0.5 + 0.5)
+      const wet2 = this.wet * ((1.0 - this.width) * 0.5)
+
+      const finalLeft = leftInput * this.dry + leftOut * wet1 + rightOut * wet2
+      const finalRight =
+        rightInput * this.dry + rightOut * wet1 + leftOut * wet2
+
+      chunk.writeInt16LE(clamp16Bit(finalLeft), i)
+      chunk.writeInt16LE(clamp16Bit(finalRight), i + 2)
+    }
+
+    return chunk
+  }
+
+  processAllpass(input, delayLine, state) {
+    const delayed = delayLine.read(0)
+    const output =
+      -input + delayed + this.allpassCoeff * (input - state.y1)
+
+    delayLine.write(clamp16Bit(input))
+    state.y1 = output
+
+    return output
+  }
+}

--- a/src/playback/filtersManager.js
+++ b/src/playback/filtersManager.js
@@ -7,10 +7,12 @@ import Compressor from './filters/compressor.js'
 import Distortion from './filters/distortion.js'
 import Echo from './filters/echo.js'
 import Equalizer from './filters/equalizer.js'
+import Flanger from './filters/flanger.js'
 import Highpass from './filters/highpass.js'
 import Karaoke from './filters/karaoke.js'
 import Lowpass from './filters/lowpass.js'
 import Phaser from './filters/phaser.js'
+import Reverb from './filters/reverb.js'
 import Rotation from './filters/rotation.js'
 import Timescale from './filters/timescale.js'
 import Tremolo from './filters/tremolo.js'
@@ -38,7 +40,9 @@ export class FiltersManager extends Transform {
       echo: new Echo(),
       phaser: new Phaser(),
       timescale: new Timescale(),
-      spatial: new Spatial()
+      spatial: new Spatial(),
+      reverb: new Reverb(),
+      flanger: new Flanger()
     }
 
     if (this.nodelink.extensions?.filters) {


### PR DESCRIPTION
## Summary
- Added a reverb filter using comb and allpass filters (Freeverb style)
- Added a flanger filter with LFO-modulated delay lines
- Both filters are now available in the FiltersManager

## Changes
- New reverb filter for natural echo and spaciousness
- New flanger filter for sweeping, swirling effects
- Both filters can be enabled and configured through the filter options

## Why
These effects are commonly used in audio processing and will give users more creative control over their sound. The implementation is efficient and fits well with the existing filter system.

## Checklist
- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with NodeLink clients.

## Additional Info

### Usage

**Reverb:**

```json
{
  "reverb": {
    "mix": 0.3,
    "roomSize": 0.7,
    "damping": 0.5,
    "width": 1.0
  }
}
```

**Flanger:**

```json
{
  "flanger": {
    "rate": 0.5,
    "depth": 0.7,
    "delay": 5,
    "feedback": 0.5,
    "mix": 0.5
  }
}
```