### PR TITLE
update: replace toddy-mediaplex with @toddynnn/voice-opus & youtube clients maintance.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     "@performanc/pwsl-server": "github:performanc/internals#PWSL-server",
     "@performanc/voice": "github:PerformanC/voice",
     "@toddynnn/symphonia-decoder": "1.0.6",
+    "@toddynnn/voice-opus": "^1.0.1",
     "mp4box": "^2.3.0",
-    "myzod": "^1.12.1",
-    "toddy-mediaplex": "^2.0.0"
+    "myzod": "^1.12.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.10",
-    "@commitlint/cli": "20.2.0",
-    "@commitlint/config-conventional": "20.2.0",
+    "@commitlint/cli": "20.3.0",
+    "@commitlint/config-conventional": "20.3.0",
     "dotenv": "^17.2.3",
     "husky": "9.1.7"
   },

--- a/src/playback/opus/Opus.js
+++ b/src/playback/opus/Opus.js
@@ -17,6 +17,7 @@ let ACTIVE_LIB = null
 const _getLib = () => {
   if (ACTIVE_LIB) return ACTIVE_LIB
   const libs = [
+    { name: '@toddynnn/voice-opus', pick: (m) => m.OpusEncoder },
     { name: 'toddy-mediaplex', pick: (m) => m.OpusEncoder },
     { name: '@discordjs/opus', pick: (m) => m.OpusEncoder },
     { name: 'opusscript', pick: (m) => m }

--- a/src/sources/youtube/clients/Android.js
+++ b/src/sources/youtube/clients/Android.js
@@ -15,9 +15,9 @@ export default class Android extends BaseClient {
     return {
       client: {
         clientName: 'ANDROID',
-        clientVersion: '20.38.37',
+        clientVersion: '20.51.39',
         userAgent:
-          'com.google.android.youtube/20.38.37 (Linux; U; Android 14) gzip',
+          'com.google.android.youtube/20.51.39 (Linux; U; Android 14) gzip',
         deviceMake: 'Google',
         deviceModel: 'Pixel 6',
         osName: 'Android',
@@ -111,7 +111,7 @@ export default class Android extends BaseClient {
           const shelf = section.shelfRenderer || section.richShelfRenderer
           contents = shelf?.content?.verticalListRenderer?.items || shelf?.content?.richGridRenderer?.contents
         }
-        
+
         if (Array.isArray(contents)) {
           for (const item of contents) {
             items.push(item.richItemRenderer?.content || item)
@@ -131,7 +131,7 @@ export default class Android extends BaseClient {
       const maxResults = this.config.maxSearchResults || 10
       let count = 0
       const filteredItems = items.filter((item) => {
-        const isValid = item.videoRenderer || item.compactVideoRenderer || 
+        const isValid = item.videoRenderer || item.compactVideoRenderer ||
                         item.playlistRenderer || item.compactPlaylistRenderer ||
                         item.channelRenderer || item.elementRenderer
         if (isValid && count < maxResults) {

--- a/src/sources/youtube/clients/Android.js
+++ b/src/sources/youtube/clients/Android.js
@@ -17,7 +17,7 @@ export default class Android extends BaseClient {
         clientName: 'ANDROID',
         clientVersion: '20.51.39',
         userAgent:
-          'com.google.android.youtube/20.51.39 (Linux; U; Android 14) gzip',
+          'com.google.android.youtube/20.51.39 (Linux; U; Android 14) identity',
         deviceMake: 'Google',
         deviceModel: 'Pixel 6',
         osName: 'Android',

--- a/src/sources/youtube/clients/AndroidVR.js
+++ b/src/sources/youtube/clients/AndroidVR.js
@@ -27,7 +27,7 @@ export default class AndroidVR extends BaseClient {
         visitorData: context.client.visitorData
       },
       user: { lockedSafetyMode: false },
-      request: { useSsl: true },
+      request: { useSsl: true }
     }
   }
 

--- a/src/sources/youtube/clients/AndroidVR.js
+++ b/src/sources/youtube/clients/AndroidVR.js
@@ -15,18 +15,19 @@ export default class AndroidVR extends BaseClient {
     return {
       client: {
         clientName: 'ANDROID_VR',
-        clientVersion: '1.65.10',
+        clientVersion: '1.71.26',
         userAgent:
-          'com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip',
+          'com.google.android.apps.youtube.vr.oculus/1.71.26 AppleWebKit/537.36 (KHTML, like Gecko) (Linux; U; Android 15; eureka-user Build/AP4A.250205.002) gzip',
+        deviceMake: 'Google',
         osName: 'Android',
-        osVersion: '12L',
-        androidSdkVersion: '32',
+        osVersion: '15',
+        androidSdkVersion: '35',
         hl: context.client.hl,
         gl: context.client.gl,
         visitorData: context.client.visitorData
       },
       user: { lockedSafetyMode: false },
-      request: { useSsl: true }
+      request: { useSsl: true },
     }
   }
 

--- a/src/sources/youtube/clients/AndroidVR.js
+++ b/src/sources/youtube/clients/AndroidVR.js
@@ -17,7 +17,7 @@ export default class AndroidVR extends BaseClient {
         clientName: 'ANDROID_VR',
         clientVersion: '1.71.26',
         userAgent:
-          'com.google.android.apps.youtube.vr.oculus/1.71.26 AppleWebKit/537.36 (KHTML, like Gecko) (Linux; U; Android 15; eureka-user Build/AP4A.250205.002) gzip',
+          'com.google.android.apps.youtube.vr.oculus/1.71.26 (Linux; U; Android 15; eureka-user Build/AP4A.250205.002) gzip',
         deviceMake: 'Google',
         osName: 'Android',
         osVersion: '15',

--- a/src/sources/youtube/clients/IOS.js
+++ b/src/sources/youtube/clients/IOS.js
@@ -15,13 +15,13 @@ export default class IOS extends BaseClient {
     return {
       client: {
         clientName: 'IOS',
-        clientVersion: '20.10.4',
+        clientVersion: '20.51.39',
         userAgent:
-          'com.google.ios.youtube/20.10.4 (iPhone16,2; U; CPU iOS 18_3_2 like Mac OS X;)',
+          'com.google.ios.youtube/20.51.39 (iPhone16,2; U; CPU iOS 18_2 like Mac OS X;)',
         deviceMake: 'Apple',
         deviceModel: 'iPhone16,2',
         osName: 'iPhone',
-        osVersion: '18.3.2.22D82',
+        osVersion: '18.2.22C152',
         utcOffsetMinutes: 0,
         hl: context.client.hl,
         gl: context.client.gl,

--- a/src/sources/youtube/clients/TV.js
+++ b/src/sources/youtube/clients/TV.js
@@ -15,8 +15,8 @@ export default class TV extends BaseClient {
     return {
       client: {
         clientName: 'TVHTML5',
-        clientVersion: '7.20250923.13.00',
-        userAgent: 'Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version',
+        clientVersion: '7.20251217.19.00',
+        userAgent: `Mozilla/5.0(SMART-TV; Linux; Tizen 4.0.0.2) AppleWebkit/605.1.15 (KHTML, like Gecko) SamsungBrowser/9.2 TV Safari/605.1.15`,
         hl: context.client.hl,
         gl: context.client.gl
       },

--- a/src/sources/youtube/clients/TV.js
+++ b/src/sources/youtube/clients/TV.js
@@ -16,7 +16,7 @@ export default class TV extends BaseClient {
       client: {
         clientName: 'TVHTML5',
         clientVersion: '7.20251217.19.00',
-        userAgent: `Mozilla/5.0(SMART-TV; Linux; Tizen 4.0.0.2) AppleWebkit/605.1.15 (KHTML, like Gecko) SamsungBrowser/9.2 TV Safari/605.1.15`,
+        userAgent: 'Mozilla/5.0(SMART-TV; Linux; Tizen 4.0.0.2) AppleWebkit/605.1.15 (KHTML, like Gecko) SamsungBrowser/9.2 TV Safari/605.1.15',
         hl: context.client.hl,
         gl: context.client.gl
       },

--- a/src/sources/youtube/clients/TVEmbedded.js
+++ b/src/sources/youtube/clients/TVEmbedded.js
@@ -16,13 +16,13 @@ export default class TVEmbedded extends BaseClient {
       client: {
         clientName: 'TVHTML5_SIMPLY_EMBEDDED_PLAYER',
         clientVersion: '2.0',
-        userAgent: 'Mozilla/5.0 (ChromiumStylePlatform) Cobalt/Version',
+        userAgent: 'Mozilla/5.0 (Linux armeabi-v7a; Android 7.1.2; Fire OS 6.0) Cobalt/22.lts.3.306369-gold (unlike Gecko) v8/8.8.278.8-jit gles Starboard/13, Amazon_ATV_mediatek8695_2019/NS6294 (Amazon, AFTMM, Wireless) com.amazon.firetv.youtube/22.3.r2.v66.0',
         hl: context.client.hl,
         gl: context.client.gl
       },
       user: { lockedSafetyMode: false },
       request: { useSsl: true },
-      thirdParty: { embedUrl: 'https://www.youtube.com' }
+      thirdParty: { embedUrl: 'https://www.youtube.com/tv' }
     }
   }
 

--- a/src/sources/youtube/clients/Web.js
+++ b/src/sources/youtube/clients/Web.js
@@ -15,10 +15,10 @@ export default class Web extends BaseClient {
     return {
       client: {
         clientName: 'WEB',
-        clientVersion: '2.20251030.01.00',
+        clientVersion: '2.20260101.00.00',
         platform: 'DESKTOP',
         userAgent:
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36,gzip(gfe)',
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36,gzip(gfe)',
         hl: context.client.hl,
         gl: context.client.gl
       },
@@ -335,7 +335,7 @@ export default class Web extends BaseClient {
       if (renderer) {
         const title = renderer.title?.simpleText || renderer.title?.runs?.[0]?.text
         const timeStr = renderer.timeDescription?.simpleText || renderer.timeDescription?.runs?.[0]?.text
-        
+
         let thumbnails = []
         if (renderer.thumbnail && renderer.thumbnail.thumbnails) {
             thumbnails = renderer.thumbnail.thumbnails


### PR DESCRIPTION
## Changes

This PR "replaces" the toddy-mediaplex package with @toddynnn/voice-opus in Opus.js
Updated all (expect music) client versions & new headers.
Updated the dependencies on package.json

## Why 

@toddynnn/voice-opus contains libopus 1.6 (not compiled with qext yet, so no experimental options enabled), this makes easier when discord decides to update to libopus 1.6 to re-compile (because there is a experimental option that enables sample rates up to 96khz & maintain the package itself.)

Replaced the gzip with identity on android headers, this disables compression (i don't really this its necessary to enable compression on this client, since its only been used for searching)

Updated all (expect music) client versions & new headers.
These new custom headers/versions reduces the detections

## Checkmarks

- [ X ] The modified endpoints have been tested.
- [ X ] Used the same indentation as the rest of the project.
- [ X ] Still compatible with LavaLink clients.

## Additional information

These headers was based off extractions from: Metrolist/Innertube & yuliskov/MediaServiceCore
i will make @toddynnn/voice-opus open source soon too
happy new year (web client 2026 :d)