### PR TITLE
Remove LICENSE, README.md, commitlint.config.mjs and biome.json from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,3 @@ logs
 Dockerfile
 docker-compose.yml
 biome.json
-commitlint.config.mjs

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,3 @@ logs
 .vscode
 Dockerfile
 docker-compose.yml
-biome.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,5 @@ logs
 .vscode
 Dockerfile
 docker-compose.yml
-LICENSE
 biome.json
 commitlint.config.mjs

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,6 @@ logs
 .vscode
 Dockerfile
 docker-compose.yml
-README.md
 LICENSE
 biome.json
 commitlint.config.mjs


### PR DESCRIPTION
## Changes

Removed LICENSE, README.md, commitlint.config.mjs and biome.json from .dockerignore

## Why 

The Dockerfile depends on these dependencies, ignoring them in .dockerignore will break it.
