### PR TITLE
fix: Failing to resolve lastfm urls with a _ in them. Made it search for `official audio` instead of going for music videos.

### DIFF
--- a/src/sources/lastfm.js
+++ b/src/sources/lastfm.js
@@ -3,12 +3,7 @@
 I added support for lfsearch:query in this file. you're welcome <3
 */
 
-import {
-  encodeTrack,
-  getBestMatch,
-  http1makeRequest,
-  logger
-} from '../utils.js'
+import { encodeTrack, getBestMatch, http1makeRequest, logger } from '../utils.js'
 
 const LASTFM_PATTERN =
   /^https?:\/\/(?:www\.)?last\.fm\/(?:[a-z]{2}\/)?music\/.+/

--- a/src/sources/lastfm.js
+++ b/src/sources/lastfm.js
@@ -3,7 +3,12 @@
 I added support for lfsearch:query in this file. you're welcome <3
 */
 
-import { encodeTrack, getBestMatch, http1makeRequest, logger } from '../utils.js'
+import {
+  encodeTrack,
+  getBestMatch,
+  http1makeRequest,
+  logger
+} from '../utils.js'
 
 const LASTFM_PATTERN =
   /^https?:\/\/(?:www\.)?last\.fm\/(?:[a-z]{2}\/)?music\/.+/
@@ -54,22 +59,16 @@ export default class LastFMSource {
   }
 
   async resolve(url) {
-    logger('debug', 'LastFM', `Starting resolve for URL: ${url}`)
-
     if (!LASTFM_PATTERN.test(url)) {
-      logger('debug', 'LastFM', 'URL does not match Last.fm pattern')
       return { loadType: 'empty', data: {} }
     }
 
     const path = this._parsePath(url)
-    logger('debug', 'LastFM', `Parsed path: ${JSON.stringify(path)}`)
     if (!path) {
-      logger('debug', 'LastFM', 'Failed to parse path from URL')
       return { loadType: 'empty', data: {} }
     }
 
     try {
-      logger('debug', 'LastFM', `Fetching page content from: ${url}`)
       const { body, error, statusCode } = await http1makeRequest(url, {
         method: 'GET'
       })
@@ -88,12 +87,6 @@ export default class LastFMSource {
         }
       }
 
-      logger(
-        'debug',
-        'LastFM',
-        `Page fetched successfully, body length: ${body?.length || 0}`
-      )
-
       // The path structure: ['music', 'Artist+Name', '_' or 'Album+Name', 'Track+Name'] Last.fm has weird URLs.
       const artist = decodeURIComponent(
         path[1]?.replace(/\+/g, ' ') || 'Unknown'
@@ -108,29 +101,13 @@ export default class LastFMSource {
       }
 
       const isTrack = path.includes('_') || path.length >= 4
-      logger(
-        'debug',
-        'LastFM',
-        `Content type: ${isTrack ? 'track' : 'album/artist'}, Artist: ${artist}, Track: ${trackTitle}`
-      )
 
       if (isTrack) {
-        logger(
-          'debug',
-          'LastFM',
-          `Searching for official audio: ${artist} - ${trackTitle}`
-        )
         const searchQuery = `${artist} - ${trackTitle} official audio`
 
         const searchResult = await this.nodelink.sources.search(
           'ytmsearch',
           searchQuery
-        )
-
-        logger(
-          'debug',
-          'LastFM',
-          `Search result loadType: ${searchResult.loadType}, count: ${searchResult.data?.length || 0}`
         )
 
         if (
@@ -198,25 +175,13 @@ export default class LastFMSource {
         }
       } else {
         // For albums/artists, try to extract YouTube URLs as before
-        logger('debug', 'LastFM', `Resolving ${artist} album/artist`)
         const youtubeUrls = this._extractYouTubeUrls(body)
-        logger(
-          'debug',
-          'LastFM',
-          `Extracted ${youtubeUrls.length} YouTube URLs`
-        )
 
         const tracks = []
 
         // We try to resolve each YouTube URL found.
         for (const youtubeUrl of youtubeUrls) {
-          logger('debug', 'LastFM', `Processing YouTube URL: ${youtubeUrl}`)
           const youtubeResult = await this.nodelink.sources.resolve(youtubeUrl)
-          logger(
-            'debug',
-            'LastFM',
-            `YouTube resolve result: ${youtubeResult.loadType}`
-          )
 
           if (youtubeResult.loadType === 'track') {
             tracks.push({
@@ -229,12 +194,6 @@ export default class LastFMSource {
             })
           }
         }
-
-        logger(
-          'debug',
-          'LastFM',
-          `Resolved ${tracks.length} tracks from YouTube URLs`
-        )
 
         if (tracks.length) {
           logger(
@@ -276,15 +235,12 @@ export default class LastFMSource {
     try {
       const urlObj = new URL(url)
       const path = urlObj.pathname.split('/').filter(Boolean)
-      logger('debug', 'LastFM', `Raw path segments: ${JSON.stringify(path)}`)
 
       if (path.length > 1 && path[0].length === 2 && path[1] === 'music') {
-        logger('debug', 'LastFM', 'Removing language code from path')
         path.shift()
       }
 
       const result = path[0] === 'music' && path.length >= 2 ? path : null
-      logger('debug', 'LastFM', `Final parsed path: ${JSON.stringify(result)}`)
       return result
     } catch (e) {
       logger('error', 'LastFM', `Error parsing path: ${e.message}`)
@@ -303,32 +259,16 @@ export default class LastFMSource {
   _extractYouTubeUrls(html) {
     const urls = new Set()
 
-    logger('debug', 'LastFM', 'Attempting to extract YouTube URLs from HTML')
-
     const playMatch = html.match(YOUTUBE_LINK_PATTERN)
     if (playMatch) {
-      logger(
-        'debug',
-        'LastFM',
-        `Found YouTube link via YOUTUBE_LINK_PATTERN: ${playMatch[1]}`
-      )
       urls.add(playMatch[1])
     }
 
     const regex = new RegExp(YOUTUBE_URL_PATTERN, 'g')
     let match
-    let urlCount = 0
     while ((match = regex.exec(html)) !== null) {
-      logger(
-        'debug',
-        'LastFM',
-        `Found YouTube URL via YOUTUBE_URL_PATTERN: ${match[0]}`
-      )
       urls.add(match[0])
-      urlCount++
     }
-
-    logger('debug', 'LastFM', `Total unique YouTube URLs found: ${urls.size}`)
 
     return Array.from(urls)
   }

--- a/src/sources/lastfm.js
+++ b/src/sources/lastfm.js
@@ -3,7 +3,12 @@
 I added support for lfsearch:query in this file. you're welcome <3
 */
 
-import { encodeTrack, getBestMatch, http1makeRequest, logger } from '../utils.js'
+import {
+  encodeTrack,
+  getBestMatch,
+  http1makeRequest,
+  logger
+} from '../utils.js'
 
 const LASTFM_PATTERN =
   /^https?:\/\/(?:www\.)?last\.fm\/(?:[a-z]{2}\/)?music\/.+/
@@ -54,19 +59,32 @@ export default class LastFMSource {
   }
 
   async resolve(url) {
+    logger('debug', 'LastFM', `Starting resolve for URL: ${url}`)
+
     if (!LASTFM_PATTERN.test(url)) {
+      logger('debug', 'LastFM', 'URL does not match Last.fm pattern')
       return { loadType: 'empty', data: {} }
     }
 
     const path = this._parsePath(url)
-    if (!path) return { loadType: 'empty', data: {} }
+    logger('debug', 'LastFM', `Parsed path: ${JSON.stringify(path)}`)
+    if (!path) {
+      logger('debug', 'LastFM', 'Failed to parse path from URL')
+      return { loadType: 'empty', data: {} }
+    }
 
     try {
+      logger('debug', 'LastFM', `Fetching page content from: ${url}`)
       const { body, error, statusCode } = await http1makeRequest(url, {
         method: 'GET'
       })
 
       if (error || statusCode !== 200) {
+        logger(
+          'error',
+          'LastFM',
+          `Failed to fetch Last.fm page: ${error?.message || statusCode}`
+        )
         return {
           exception: {
             message: `Failed to fetch Last.fm page: ${error?.message || statusCode}`,
@@ -75,39 +93,136 @@ export default class LastFMSource {
         }
       }
 
-      const youtubeUrls = this._extractYouTubeUrls(body)
-      if (!youtubeUrls.length) {
-        return {
-          exception: {
-            message: 'No YouTube URLs found on Last.fm page',
-            severity: 'common'
-          }
-        }
+      logger(
+        'debug',
+        'LastFM',
+        `Page fetched successfully, body length: ${body?.length || 0}`
+      )
+
+      // The path structure: ['music', 'Artist+Name', '_' or 'Album+Name', 'Track+Name'] Last.fm has weird URLs.
+      const artist = decodeURIComponent(
+        path[1]?.replace(/\+/g, ' ') || 'Unknown'
+      )
+
+      // We just skip the _ if it's there and extract the title and artist.
+      let trackTitle = 'Unknown'
+      if (path[2] === '_' && path[3]) {
+        trackTitle = decodeURIComponent(path[3].replace(/\+/g, ' '))
+      } else if (path[2]) {
+        trackTitle = decodeURIComponent(path[2].replace(/\+/g, ' '))
       }
 
       const isTrack = path.includes('_') || path.length >= 4
+      logger(
+        'debug',
+        'LastFM',
+        `Content type: ${isTrack ? 'track' : 'album/artist'}, Artist: ${artist}, Track: ${trackTitle}`
+      )
 
       if (isTrack) {
-        const youtubeResult = await this.nodelink.sources.resolve(
-          youtubeUrls[0]
+        logger(
+          'debug',
+          'LastFM',
+          `Searching for official audio: ${artist} - ${trackTitle}`
         )
-        if (youtubeResult.loadType === 'track') {
+        const searchQuery = `${artist} - ${trackTitle} official audio`
+
+        const searchResult = await this.nodelink.sources.search(
+          'ytmsearch',
+          searchQuery
+        )
+
+        logger(
+          'debug',
+          'LastFM',
+          `Search result loadType: ${searchResult.loadType}, count: ${searchResult.data?.length || 0}`
+        )
+
+        if (
+          searchResult.loadType === 'search' &&
+          searchResult.data?.length > 0
+        ) {
+          const bestTrack = searchResult.data[0]
+          logger(
+            'info',
+            'LastFM',
+            `Found official audio track: ${bestTrack.info.title} by ${bestTrack.info.author}`
+          )
           return {
             loadType: 'track',
             data: {
-              ...youtubeResult.data,
+              ...bestTrack,
               info: {
-                ...youtubeResult.data.info,
+                ...bestTrack.info,
                 uri: url,
                 sourceName: 'lastfm'
               }
             }
           }
         }
+
+        logger(
+          'warn',
+          'LastFM',
+          'No official audio found, attempting to search without "official audio" qualifier'
+        )
+        const fallbackSearch = await this.nodelink.sources.search(
+          'ytmsearch',
+          `${artist} - ${trackTitle}`
+        )
+
+        if (
+          fallbackSearch.loadType === 'search' &&
+          fallbackSearch.data?.length > 0
+        ) {
+          const bestTrack = fallbackSearch.data[0]
+          logger(
+            'info',
+            'LastFM',
+            `Found track via fallback: ${bestTrack.info.title} by ${bestTrack.info.author}`
+          )
+          return {
+            loadType: 'track',
+            data: {
+              ...bestTrack,
+              info: {
+                ...bestTrack.info,
+                uri: url,
+                sourceName: 'lastfm'
+              }
+            }
+          }
+        }
+
+        logger('error', 'LastFM', 'No tracks found for this Last.fm track')
+        return {
+          exception: {
+            message: 'No matching tracks found for this Last.fm track',
+            severity: 'fault'
+          }
+        }
       } else {
+        // For albums/artists, try to extract YouTube URLs as before
+        logger('debug', 'LastFM', `Resolving ${artist} album/artist`)
+        const youtubeUrls = this._extractYouTubeUrls(body)
+        logger(
+          'debug',
+          'LastFM',
+          `Extracted ${youtubeUrls.length} YouTube URLs`
+        )
+
         const tracks = []
+
+        // We try to resolve each YouTube URL found.
         for (const youtubeUrl of youtubeUrls) {
+          logger('debug', 'LastFM', `Processing YouTube URL: ${youtubeUrl}`)
           const youtubeResult = await this.nodelink.sources.resolve(youtubeUrl)
+          logger(
+            'debug',
+            'LastFM',
+            `YouTube resolve result: ${youtubeResult.loadType}`
+          )
+
           if (youtubeResult.loadType === 'track') {
             tracks.push({
               ...youtubeResult.data,
@@ -120,33 +235,42 @@ export default class LastFMSource {
           }
         }
 
+        logger(
+          'debug',
+          'LastFM',
+          `Resolved ${tracks.length} tracks from YouTube URLs`
+        )
+
         if (tracks.length) {
-          const artist = decodeURIComponent(
-            path[2]?.replace(/\+/g, ' ') || 'Unknown'
-          )
-          const album = decodeURIComponent(
-            path[3]?.replace(/\+/g, ' ') ||
-              path[1]?.replace(/\+/g, ' ') ||
-              'Unknown'
+          logger(
+            'info',
+            'LastFM',
+            `Resolved playlist: ${trackTitle} - ${artist} with ${tracks.length} tracks`
           )
           return {
             loadType: 'playlist',
             data: {
-              info: { name: `${album} - ${artist}`, selectedTrack: 0 },
+              info: { name: `${trackTitle} - ${artist}`, selectedTrack: 0 },
               pluginInfo: {},
               tracks
             }
           }
         }
-      }
 
-      return {
-        exception: {
-          message: 'Failed to resolve YouTube URLs from Last.fm',
-          severity: 'fault'
+        logger(
+          'error',
+          'LastFM',
+          'Failed to resolve any tracks from Last.fm album/artist'
+        )
+        return {
+          exception: {
+            message: 'Failed to resolve tracks from Last.fm',
+            severity: 'fault'
+          }
         }
       }
     } catch (e) {
+      logger('error', 'LastFM', `Exception during resolve: ${e.message}`, e)
       return {
         exception: { message: e.message, severity: 'fault' }
       }
@@ -157,11 +281,18 @@ export default class LastFMSource {
     try {
       const urlObj = new URL(url)
       const path = urlObj.pathname.split('/').filter(Boolean)
+      logger('debug', 'LastFM', `Raw path segments: ${JSON.stringify(path)}`)
+
       if (path.length > 1 && path[0].length === 2 && path[1] === 'music') {
+        logger('debug', 'LastFM', 'Removing language code from path')
         path.shift()
       }
-      return path[0] === 'music' && path.length >= 2 ? path : null
-    } catch {
+
+      const result = path[0] === 'music' && path.length >= 2 ? path : null
+      logger('debug', 'LastFM', `Final parsed path: ${JSON.stringify(result)}`)
+      return result
+    } catch (e) {
+      logger('error', 'LastFM', `Error parsing path: ${e.message}`)
       return null
     }
   }
@@ -177,14 +308,32 @@ export default class LastFMSource {
   _extractYouTubeUrls(html) {
     const urls = new Set()
 
+    logger('debug', 'LastFM', 'Attempting to extract YouTube URLs from HTML')
+
     const playMatch = html.match(YOUTUBE_LINK_PATTERN)
-    if (playMatch) urls.add(playMatch[1])
+    if (playMatch) {
+      logger(
+        'debug',
+        'LastFM',
+        `Found YouTube link via YOUTUBE_LINK_PATTERN: ${playMatch[1]}`
+      )
+      urls.add(playMatch[1])
+    }
 
     const regex = new RegExp(YOUTUBE_URL_PATTERN, 'g')
     let match
+    let urlCount = 0
     while ((match = regex.exec(html)) !== null) {
+      logger(
+        'debug',
+        'LastFM',
+        `Found YouTube URL via YOUTUBE_URL_PATTERN: ${match[0]}`
+      )
       urls.add(match[0])
+      urlCount++
     }
+
+    logger('debug', 'LastFM', `Total unique YouTube URLs found: ${urls.size}`)
 
     return Array.from(urls)
   }
@@ -280,7 +429,10 @@ export default class LastFMSource {
 
     if (body?.error) {
       return {
-        exception: { message: body.message || 'Last.fm API error', severity: 'fault' }
+        exception: {
+          message: body.message || 'Last.fm API error',
+          severity: 'fault'
+        }
       }
     }
 
@@ -296,7 +448,9 @@ export default class LastFMSource {
       const list = Array.isArray(albums) ? albums : [albums]
       return list
         .filter((item) => item?.name && item?.artist)
-        .map((item) => this._buildCollectionResult(item.name, item.artist, item.url, 'album'))
+        .map((item) =>
+          this._buildCollectionResult(item.name, item.artist, item.url, 'album')
+        )
     }
 
     if (searchType === 'artist') {
@@ -304,7 +458,9 @@ export default class LastFMSource {
       const list = Array.isArray(artists) ? artists : [artists]
       return list
         .filter((item) => item?.name)
-        .map((item) => this._buildCollectionResult(item.name, 'Last.fm', item.url, 'artist'))
+        .map((item) =>
+          this._buildCollectionResult(item.name, 'Last.fm', item.url, 'artist')
+        )
     }
 
     const tracks = body?.results?.trackmatches?.track || []


### PR DESCRIPTION
## Changes
Fixed last.fm links containing underscores in the URL 
Modified the search query to use 'official audio' instead of music videos. 

## Why 
The URLs with underscores were failing to resolve when processing, Which caused it to fail when playing.

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information
Testing has been complete and is confirmed to be working properly.
