### PR TITLE
fix: correctly decode and validate basic auth for metrics (#151)

### DIFF
--- a/.github/ISSUE_TEMPLATE/woc-feat-request.yaml
+++ b/.github/ISSUE_TEMPLATE/woc-feat-request.yaml
@@ -1,0 +1,59 @@
+name: "Winter of Code: Feature Request"
+description: "Suggest an improvement or new feature"
+title: "[FR]: "
+labels: ["enhancement", "Winter-of-Code", "not confirmed"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Keep it simple: problem → proposal → why it helps.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      placeholder: "What’s painful or missing today?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      placeholder: "What should the project do instead? (behavior/API/config)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives / workarounds (optional)
+      placeholder: "What are you doing today to work around it?"
+    validations:
+      required: false
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example usage (optional)
+      render: javascript
+      placeholder: "Small snippet or sample config."
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: woc
+    attributes:
+      label: Winter of Code
+      options:
+        - label: I’m a Winter of Code participant and I’d like to implement this.
+          required: false
+
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Quick checks
+      options:
+        - label: I searched existing issues/requests to avoid duplicates.
+          required: true

--- a/.github/ISSUE_TEMPLATE/woc-issue-report.yaml
+++ b/.github/ISSUE_TEMPLATE/woc-issue-report.yaml
@@ -1,7 +1,7 @@
 name: Winter of Code | Issue Report
 description: Report an issue, For Winter of Code participants!
-title: "[BUG]: "
-labels: ["bug", "not confirmed"]
+title: "[WOC | BUG]: "
+labels: ["Winter-of-Code", "bug", "not confirmed"]
 
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/woc-issue-report.yaml
+++ b/.github/ISSUE_TEMPLATE/woc-issue-report.yaml
@@ -1,0 +1,73 @@
+name: Winter of Code | Issue Report
+description: Report an issue, For Winter of Code participants!
+title: "[BUG]: "
+labels: ["bug", "not confirmed"]
+
+body:
+  - type: input
+    id: version
+    attributes:
+      label: NodeLink version
+      description: The version of NodeLink you're using.
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: client
+    attributes:
+      label: Client
+      description: The client you're using.
+    validations:
+      required: false
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: example
+    attributes:
+      label: Example code
+      description: If you have an example of how to reproduce the bug, please share it here.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: woc
+    attributes:
+      label: Winter of Code
+      options:
+        - label: I’m a Winter of Code participant and I’d like to work on fixing this.
+          required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Confirmations
+      description: The following confirmations are required to open a bug report.
+      options:
+        - label: My environment meets the minimum requirements.
+          required: true
+        - label: I have verified that this is not a duplicate issue.
+          required: true
+
+  - type: checkboxes
+    id: code_of_conduct
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/PerformanC/NodeLink/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/config.default.js
+++ b/config.default.js
@@ -341,6 +341,7 @@ export default {
     enabled: true,
     authorization: {
       type: 'Bearer', // Bearer or Basic.
+      username: 'admin',
       password: '' // If empty, uses server.password
     }
   },

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -135,22 +135,31 @@ async function requestHandler(nodelink, req, res) {
       authType = 'Bearer'
     }
 
+    const metricsUsername = authConfig.username || 'admin' 
     const metricsPassword =
       authConfig.password || nodelink.options.server.password
 
     const authHeader = req.headers?.authorization
     const isValidAuth =
       authHeader === metricsPassword ||
-      (authType === 'Bearer' && authHeader === `Bearer ${metricsPassword}` ||
+      (authType === 'Bearer' && authHeader === `Bearer ${metricsPassword}`) ||
       (authType === 'Basic' && (() => {
         try {
+          // 1. Decode the "user:pass" string
           const decoded = Buffer.from(authHeader.slice(6), 'base64').toString('utf8')
-          const pass = decoded.includes(':') ? decoded.split(':')[1] : decoded
-          return pass === metricsPassword
+          
+          // 2. Split by the first colon (passwords can contain colons!)
+          const colonIndex = decoded.indexOf(':')
+          if (colonIndex === -1) return false // Invalid format
+          
+          const user = decoded.slice(0, colonIndex)
+          const pass = decoded.slice(colonIndex + 1)
+          
+          return user === metricsUsername && pass === metricsPassword  //verify both
         } catch {
           return false
         }
-      })()))
+      })())
 
     if (!isValidAuth) {
       logger(

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -141,10 +141,16 @@ async function requestHandler(nodelink, req, res) {
     const authHeader = req.headers?.authorization
     const isValidAuth =
       authHeader === metricsPassword ||
-      (authType === 'Bearer' &&
-        authHeader === `${authType} ${metricsPassword}`) ||
-      (authType === 'Basic' &&
-        authHeader === `${authType} ${atob(authHeader.slice(authType.length))}`)
+      (authType === 'Bearer' && authHeader === `Bearer ${metricsPassword}` ||
+      (authType === 'Basic' && (() => {
+        try {
+          const decoded = Buffer.from(authHeader.slice(6), 'base64').toString('utf8')
+          const pass = decoded.includes(':') ? decoded.split(':')[1] : decoded
+          return pass === metricsPassword
+        } catch {
+          return false
+        }
+      })()))
 
     if (!isValidAuth) {
       logger(


### PR DESCRIPTION
## Changes

Write here about the changes you've made

## Why 

Write here why you think this should be merged

Critical auth bug, read issue #151 

## Checkmarks

- [X] The modified endpoints have been tested.
- [X] Used the same indentation as the rest of the project.
- [X] Still compatible with LavaLink clients.

## Additional information

If you have any additional information, write it here

Basic YWRtaW46eW91c2hhbGxub3RwYXNz" === "Basic admin:youshallnotpass -> FALSE || 401
new code does is decoding the base64 and breaks after :  and checks the password 
