### PR TITLE
update: limit content-length to 10mb on api

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -236,13 +236,59 @@ async function requestHandler(nodelink, req, res) {
     }
   }
 
+  const MAX_BODY_SIZE = 10 * 1024 * 1024
+
   let body = ''
   if (req.method !== 'GET') {
+    const contentLength = parseInt(req.headers['content-length'])
+    if (!isNaN(contentLength) && contentLength > MAX_BODY_SIZE) {
+      logger(
+        'warn',
+        'Server',
+        `Request rejected: Content-Length ${contentLength} exceeds limit of ${MAX_BODY_SIZE}`
+      )
+      sendErrorResponse(
+        req,
+        res,
+        413,
+        'Payload Too Large',
+        'Request body is too large.',
+        parsedUrl.pathname,
+        trace
+      )
+      req.destroy()
+      return
+    }
+
     await new Promise((resolve) => {
-      req.on('data', (chunk) => {
+      let receivedSize = 0
+
+      const onData = (chunk) => {
+        receivedSize += chunk.length
+        if (receivedSize > MAX_BODY_SIZE) {
+          logger(
+            'warn',
+            'Server',
+            `Request rejected: Body size exceeded limit of ${MAX_BODY_SIZE}`
+          )
+          req.removeListener('data', onData)
+          req.removeListener('end', onEnd)
+          sendErrorResponse(
+            req,
+            res,
+            413,
+            'Payload Too Large',
+            'Request body is too large.',
+            parsedUrl.pathname,
+            trace
+          )
+          req.destroy()
+          return
+        }
         body += chunk.toString()
-      })
-      req.on('end', () => {
+      }
+
+      const onEnd = () => {
         try {
           if (
             req.headers['content-type']?.includes('application/json') &&
@@ -268,7 +314,10 @@ async function requestHandler(nodelink, req, res) {
           return
         }
         resolve()
-      })
+      }
+
+      req.on('data', onData)
+      req.on('end', onEnd)
     })
   }
   req.body = body

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -236,7 +236,7 @@ async function requestHandler(nodelink, req, res) {
     }
   }
 
-  const MAX_BODY_SIZE = 10 * 1024 * 1024
+  const MAX_BODY_SIZE = nodelink.options.server?.maxBodySize || 10 * 1024 * 1024
 
   let body = ''
   if (req.method !== 'GET') {

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -283,7 +283,7 @@ async function requestHandler(nodelink, req, res) {
             trace
           )
           req.destroy()
-          return
+          resolve()
         }
         body += chunk.toString()
       }


### PR DESCRIPTION
This commit fixes the issue https://github.com/PerformanC/NodeLink/issues/149, by limiting the  content-length. If it exceeds the value (10mb), will be rejected with code 413.

## Changes

Write here about the changes you've made

## Why 

Write here why you think this should be merged

## Checkmarks

- [ ] The modified endpoints have been tested.
- [ ] Used the same indentation as the rest of the project.
- [ ] Still compatible with LavaLink clients.

## Additional information

If you have any additional information, write it here
