### PR TITLE
improve: fully refactor the sabr implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@performanc/voice": "github:PerformanC/voice",
     "@toddynnn/symphonia-decoder": "1.0.6",
     "@toddynnn/voice-opus": "^1.0.1",
+    "jsdom": "^27.4.0",
     "mp4box": "^2.3.0",
     "myzod": "^1.12.1"
   },

--- a/src/playback/player.js
+++ b/src/playback/player.js
@@ -590,6 +590,7 @@ export class Player {
       audioTrackId: this.track.audioTrackId
     }
     const urlData = await this.nodelink.sources.getTrackUrl(trackInfo)
+    if (!this.track) return false
     this.streamInfo = { ...urlData, trackInfo: this.track.info }
     logger('debug', 'Player', `Got track URL for guild ${this.guildId}`, {
       urlData
@@ -796,6 +797,7 @@ export class Player {
               audioTrackId: this.track.audioTrackId
             }
             const urlData = await this.nodelink.sources.getTrackUrl(trackInfo)
+            if (!this.track) return false
             this.streamInfo = { ...urlData, trackInfo: this.track.info }
             logger(
               'debug',
@@ -926,6 +928,7 @@ export class Player {
       audioTrackId: this.track.audioTrackId
     }
     const urlData = await this.nodelink.sources.getTrackUrl(trackInfo)
+    if (!this.track) return false
     this.streamInfo = { ...urlData, trackInfo: this.track.info }
 
     if (urlData.exception) {

--- a/src/sources/youtube/YouTube.js
+++ b/src/sources/youtube/YouTube.js
@@ -232,7 +232,7 @@ async function _manageYoutubeHlsStream(
 
         if (res.error || res.statusCode !== 200) {
           if (res.stream) res.stream.destroy()
-          
+
           let retryCount = 0
           let success = false
           while (retryCount < 3 && !cancelSignal.aborted) {
@@ -978,7 +978,8 @@ export default class YouTubeSource {
   }
 
   async getTrackUrl(decodedTrack, itag) {
-    const clientList = this.config.clients.playback
+    let clientList = [...this.config.clients.playback]
+    clientList = ['Web', ...clientList.filter(c => c !== 'Web') || 'Android']
     const clientErrors = []
 
     for (const clientName of clientList) {
@@ -1012,6 +1013,16 @@ export default class YouTubeSource {
         }
 
         if (urlData.protocol === 'sabr') {
+          const bestAudio = urlData.formats
+            ?.filter((f) => f.mimeType?.includes('audio'))
+            .sort((a, b) => (b.bitrate || 0) - (a.bitrate || 0))[0]
+
+          if (bestAudio) {
+            urlData.format = bestAudio.mimeType?.includes('webm')
+              ? 'webm/opus'
+              : 'm4a'
+          }
+
           return urlData
         }
 
@@ -1176,15 +1187,45 @@ export default class YouTubeSource {
 
         const stream = new PassThrough()
 
-        sabr.on('data', (chunk) => stream.write(chunk))
+        sabr.on('data', (chunk) => {
+          if (!stream.write(chunk)) {
+            sabr.pause()
+          }
+        })
+        stream.on('drain', () => sabr.resume())
+
         sabr.on('end', () => stream.end())
-        sabr.on('error', (err) => {
+        sabr.on('error', async (err) => {
           logger('error', 'YouTube', `SABR stream error: ${err.message}`)
-          stream.destroy(err)
+
+          if ((err.message.includes('sabr.malformed_config') || err.message.includes('sabr.media_serving_enforcement_id_error')) && !isRecovering) {
+            logger('info', 'YouTube', `Known recoverable error detected (${err.message}), triggering stall recovery...`)
+            sabr.emit('stall')
+            return
+          }
+
+          if (!stream.destroyed) stream.destroy(err)
+        })
+
+        const originalDestroy = stream.destroy.bind(stream)
+        let isDestroying = false
+        stream.destroy = (err) => {
+          if (isDestroying) return
+          isDestroying = true
+          sabr.destroy(err)
+          this.activeStreams.delete(streamKey)
+          originalDestroy(err)
+        }
+
+        stream.once('close', () => {
+          if (isDestroying) return
+          isDestroying = true
+          sabr.destroy()
+          this.activeStreams.delete(streamKey)
         })
 
         const bestAudio = additionalData.formats.filter(f => f.mimeType?.includes('audio')).sort((a, b) => (b.bitrate || 0) - (a.bitrate || 0))[0]
-        
+
         sabr.start(bestAudio.itag)
 
         const type = bestAudio.mimeType?.includes('webm') ? 'webm/opus' : 'm4a'

--- a/src/sources/youtube/clients/Android.js
+++ b/src/sources/youtube/clients/Android.js
@@ -314,6 +314,46 @@ export default class Android extends BaseClient {
       return { exception: { message, severity: 'common', cause: 'Upstream' } }
     }
 
+    const streamingData = playerResponse.streamingData || playerResponse.streaming_data
+    const serverAbrUrl = streamingData?.serverAbrStreamingUrl || streamingData?.server_abr_streaming_url
+    const ustreamerConfig = playerResponse.playerConfig?.mediaCommonConfig?.mediaUstreamerRequestConfig?.videoPlaybackUstreamerConfig
+
+    if (serverAbrUrl) {
+      logger('debug', 'YouTube-Android', `SABR URL found for ${decodedTrack.identifier}. Using SABR protocol.`)
+
+      const formats = [...(streamingData.formats || []), ...(streamingData.adaptiveFormats || streamingData.adaptive_formats || [])].map(f => ({
+        itag: f.itag,
+        lastModified: f.lastModified || f.last_modified_ms,
+        xtags: f.xtags,
+        width: f.width,
+        height: f.height,
+        mimeType: f.mimeType || f.mime_type,
+        audioQuality: f.audioQuality || f.audio_quality,
+        bitrate: f.bitrate,
+        averageBitrate: f.averageBitrate || f.average_bitrate,
+        quality: f.quality,
+        qualityLabel: f.qualityLabel || f.quality_label,
+        audioTrackId: f.audioTrack?.id,
+        approxDurationMs: f.approxDurationMs || f.approx_duration_ms,
+        contentLength: f.contentLength || f.content_length,
+        isDrc: !!f.isDrc
+      }))
+
+      return {
+        protocol: 'sabr',
+        url: serverAbrUrl,
+        additionalData: {
+          serverAbrStreamingUrl: serverAbrUrl,
+          videoPlaybackUstreamerConfig: ustreamerConfig,
+          visitorData: this.getClient(context).client.visitorData,
+          clientInfo: { clientName: 3, clientVersion: '20.51.39' },
+          formats,
+          accessToken: null,
+          userAgent: this.getClient(context).client.userAgent
+        }
+      }
+    }
+
     return await this._extractStreamData(
       playerResponse,
       decodedTrack,

--- a/src/sources/youtube/clients/Web.js
+++ b/src/sources/youtube/clients/Web.js
@@ -5,12 +5,12 @@ import {
   buildTrack,
   checkURLType
 } from '../common.js'
-import { PoTokenManager } from '../potoke.js'
+import { poTokenManager } from '../potoke.js'
 
 export default class Web extends BaseClient {
   constructor(nodelink, oauth) {
     super(nodelink, 'WEB', oauth)
-    this.poTokenManager = new PoTokenManager()
+    this.poTokenManager = poTokenManager
   }
 
   getClient(context) {
@@ -255,7 +255,7 @@ export default class Web extends BaseClient {
     }
 
     const { poToken, visitorData } = await this.poTokenManager.generate(decodedTrack.identifier)
-    
+
     if (poToken) {
       const client = this.getClient(context)
       client.client.visitorData = visitorData
@@ -288,7 +288,7 @@ export default class Web extends BaseClient {
 
       try {
         const { body: playerResponse } = await makeRequest(
-          'https://youtubei.googleapis.com/youtubei/v1/player?prettyPrint=false', 
+          'https://youtubei.googleapis.com/youtubei/v1/player?prettyPrint=false',
           {
             method: 'POST',
             headers: {
@@ -310,7 +310,7 @@ export default class Web extends BaseClient {
 
         if (serverAbrUrl) {
           const playerScript = await cipherManager.getCachedPlayerScript()
-          
+
           let resolvedUrl = serverAbrUrl
           if (playerScript) {
             try {

--- a/src/sources/youtube/potoke.js
+++ b/src/sources/youtube/potoke.js
@@ -1,85 +1,428 @@
-import { Buffer } from 'node:buffer'
-import { base64ToU8 } from './protor.js'
+import { Buffer } from 'node:buffer';
+import { base64ToU8 } from './protor.js';
+import { appendFile } from 'node:fs/promises';
+import path from 'node:path';
+import { logger } from '../../utils.js';
+import { JSDOM } from 'jsdom';
+
+const TOKENS_LOG_PATH = path.join(process.cwd(), 'po_tokens.jsonl');
 
 const PO_CONFIG = {
   apiKey: 'AIzaSyDyT5W0Jh49F30Pqqtyfdf7pDLFKLJoAnw',
-  userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36',
-  clientVersion: '2.20260107.01.00',
-  integrityUrl: 'https://www.youtube.com/api/jnn/v1/GenerateIT'
+  userAgent:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36',
+  ytBaseUrl: 'https://www.youtube.com',
+  googBaseUrl: 'https://jnn-pa.googleapis.com'
 };
 
-export class PoTokenManager {
-  async generate(videoId) {
+const textEncoder = new TextEncoder();
+
+class DeferredPromise {
+  constructor() {
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
+function u8ToBase64(u8, base64url = false) {
+  if (!base64url) return Buffer.from(u8).toString('base64');
+
+  if (Buffer.isEncoding?.('base64url')) {
+    return Buffer.from(u8).toString('base64url');
+  }
+  let s = Buffer.from(u8).toString('base64').replaceAll('+', '-').replaceAll('/', '_');
+  const pad = s.indexOf('=');
+  return pad === -1 ? s : s.slice(0, pad);
+}
+
+function buildURL(endpointName, useYouTubeAPI) {
+  return `${useYouTubeAPI ? PO_CONFIG.ytBaseUrl : PO_CONFIG.googBaseUrl}/${useYouTubeAPI ? 'api/jnn/v1' : '$rpc/google.internal.waa.v1.Waa'}/${endpointName}`;
+}
+
+class BotGuardClient {
+  constructor(options) {
+    this.deferredVmFunctions = new DeferredPromise();
+    this.defaultTimeout = 3000;
+    this.vm = options.globalObj[options.globalName];
+    this.program = options.program;
+  }
+
+  static async create(options) {
+    return await new BotGuardClient(options).load();
+  }
+
+  async load() {
+    if (!this.vm) throw new Error('VM not found');
+    if (!this.vm.a) throw new Error('VM init function not found');
+
+    const vmFunctionsCallback = (asyncSnapshotFunction, shutdownFunction, passEventFunction, checkCameraFunction) => {
+      this.deferredVmFunctions.resolve({
+        asyncSnapshotFunction,
+        shutdownFunction,
+        passEventFunction,
+        checkCameraFunction
+      });
+    };
+
     try {
-      const { visitorData, botguardData } = await this.getPageContext(videoId);
-      const { snapshot } = await this.createSnapshot();
-      const integrityToken = await this.requestIntegrityToken(snapshot, botguardData.requestKey);
-      const poToken = await this.bindToken(integrityToken, visitorData);
-      return { poToken, visitorData };
+      this.syncSnapshotFunction = (await this.vm.a(this.program, vmFunctionsCallback, true, undefined, () => {}, [[], []]))[0];
     } catch (error) {
-      return { poToken: null, visitorData: null };
+      throw new Error(`Could not load program: ${error.message}`);
+    }
+
+    return this;
+  }
+
+  async snapshot(args, timeout = this.defaultTimeout) {
+    const vmFunctions = await this.deferredVmFunctions.promise;
+    if (!vmFunctions.asyncSnapshotFunction) throw new Error('Asynchronous snapshot function not found');
+
+    return await new Promise((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('VM operation timed out')), timeout);
+      t.unref?.();
+
+      vmFunctions.asyncSnapshotFunction((response) => {
+        clearTimeout(t);
+        resolve(response);
+      }, [args.contentBinding, args.signedTimestamp, args.webPoSignalOutput, args.skipPrivacyBuffer]);
+    });
+  }
+}
+
+class WebPoMinter {
+  constructor(mintCallback) {
+    this.mintCallback = mintCallback;
+  }
+
+  static async create(integrityToken, webPoSignalOutput) {
+    const getMinter = webPoSignalOutput[0];
+    if (!getMinter) throw new Error('PMD:Undefined');
+    if (!integrityToken) throw new Error('No integrity token provided');
+
+    const mintCallback = await getMinter(base64ToU8(integrityToken));
+    if (!(mintCallback instanceof Function)) throw new Error('APF:Failed');
+
+    return new WebPoMinter(mintCallback);
+  }
+
+  async mintAsWebsafeString(identifier) {
+    return u8ToBase64(await this.mint(identifier), true);
+  }
+
+  async mint(identifier) {
+    const result = await this.mintCallback(textEncoder.encode(identifier));
+    if (!result) throw new Error('YNJ:Undefined');
+    if (!(result instanceof Uint8Array)) throw new Error('ODM:Invalid');
+    return result;
+  }
+}
+
+export class PoTokenManager {
+  constructor() {
+    this.botguard = null;
+    this.minter = null;
+    this.visitorData = null;
+    this.integrityToken = null;
+
+    this._dom = null;
+    this._prevGlobals = null;
+  }
+
+  _applyDomGlobals(dom) {
+    if (!this._prevGlobals) {
+      const g = globalThis;
+      this._prevGlobals = {
+        window: g.window,
+        document: g.document,
+        location: g.location,
+        origin: g.origin,
+        hadNavigator: Reflect.has(g, 'navigator')
+      };
+    }
+
+    Object.assign(globalThis, {
+      window: dom.window,
+      document: dom.window.document,
+      location: dom.window.location,
+      origin: dom.window.origin
+    });
+
+    if (!this._prevGlobals.hadNavigator) {
+      Object.defineProperty(globalThis, 'navigator', { value: dom.window.navigator, configurable: true });
     }
   }
 
-  async getPageContext(videoId) {
-    const res = await fetch(`https://www.youtube.com/watch?v=${videoId}`, {
-      headers: { 'User-Agent': PO_CONFIG.userAgent }
-    });
-    const html = await res.text();
-    const visitorDataMatch = html.match(/"visitorData":"([^"]+)"/);
-    if (!visitorDataMatch) throw new Error('Could not find visitorData');
-    const visitorData = visitorDataMatch[1];
-    const stsMatch = html.match(/"signatureTimestamp":(\d+)/);
-    const signatureTimestamp = stsMatch ? parseInt(stsMatch[1]) : 20455;
+  _cleanupDom() {
+    if (this._dom) {
+      this._dom.window.close();
+      this._dom = null;
+    }
 
-    const playerRes = await fetch('https://youtubei.googleapis.com/youtubei/v1/player', {
+    const p = this._prevGlobals;
+    if (!p) return;
+
+    const g = globalThis;
+    for (const k of ['window', 'document', 'location', 'origin']) {
+      if (p[k] === undefined) delete g[k];
+      else g[k] = p[k];
+    }
+    if (!p.hadNavigator) delete g.navigator;
+
+    this._prevGlobals = null;
+  }
+
+  async fetchVisitorData() {
+    try {
+      const response = await fetch('https://www.youtube.com', {
+        headers: { 'user-agent': PO_CONFIG.userAgent }
+      });
+      const html = await response.text();
+
+      const marker = '"VISITOR_DATA":"';
+      const start = html.indexOf(marker);
+      if (start !== -1) {
+        const from = start + marker.length;
+        const end = html.indexOf('"', from);
+        if (end !== -1) return html.slice(from, end);
+      }
+
+      throw new Error('Could not find visitorData in HTML');
+    } catch (error) {
+      logger('error', 'PoToken', `Failed to fetch visitorData: ${error.message}`);
+      return '';
+    }
+  }
+
+  async getAttestationChallenge(visitorData) {
+    const response = await fetch(`${PO_CONFIG.ytBaseUrl}/youtubei/v1/att/get?key=${PO_CONFIG.apiKey}`, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': PO_CONFIG.userAgent,
-        'X-Goog-Visitor-Id': visitorData
+        'content-type': 'application/json',
+        'user-agent': PO_CONFIG.userAgent,
+        'x-goog-api-key': PO_CONFIG.apiKey,
+        'x-youtube-client-name': '1',
+        'x-youtube-client-version': '2.20260114.01.00'
       },
       body: JSON.stringify({
-        videoId,
-        playbackContext: { contentPlaybackContext: { signatureTimestamp } },
-        context: { client: { clientName: 'WEB', clientVersion: PO_CONFIG.clientVersion, visitorData, userAgent: PO_CONFIG.userAgent } }
+        context: {
+          client: {
+            clientName: 'WEB',
+            clientVersion: '2.20260114.01.00',
+            visitorData
+          }
+        },
+        engagementType: 'ENGAGEMENT_TYPE_UNBOUND'
       })
     });
 
-    const body = await playerRes.json();
-    const botguardData = body.botguardData || { requestKey: 'fixed_key' };
-    return { visitorData, botguardData };
+    const text = await response.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      throw new Error(`Failed to parse attestation response (Status ${response.status}): ${text.slice(0, 500)}`);
+    }
+
+    if (!data.bgChallenge) throw new Error(`No bgChallenge in response: ${text.slice(0, 500)}`);
+
+    return {
+      bg_challenge: {
+        program: data.bgChallenge.program,
+        global_name: data.bgChallenge.globalName,
+        interpreter_url: {
+          private_do_not_access_or_else_trusted_resource_url_wrapped_value:
+            data.bgChallenge.interpreterUrl.privateDoNotAccessOrElseTrustedResourceUrlWrappedValue
+        }
+      }
+    };
   }
 
-  async createSnapshot() {
-    const signals = new Uint8Array([0x12, 0x1a, 0x0a, 0x08, 0x01, 0x12, 0x04, 0x08, 0x01, 0x10, 0x01]);
-    return { snapshot: Buffer.from(signals).toString('base64'), signals };
-  }
+  async initialize() {
+    if (this.botguard && this.minter) return;
 
-  async requestIntegrityToken(snapshot, requestKey) {
-    const res = await fetch(PO_CONFIG.integrityUrl, {
-      method: 'POST',
-      headers: { 
-        'Content-Type': 'application/json+protobuf', 
-        'X-Goog-Api-Key': PO_CONFIG.apiKey,
-        'X-User-Agent': 'grpc-web-javascript/0.1'
-      },
-      body: JSON.stringify([requestKey, snapshot])
+    logger('debug', 'PoToken', 'Initializing BotGuard...');
+
+    this.visitorData = await this.fetchVisitorData();
+    logger('debug', 'PoToken', `VisitorData: ${this.visitorData?.slice(0, 20)}...`);
+
+    this._cleanupDom();
+    this._dom = new JSDOM('<!DOCTYPE html><html lang="en"><head><title></title></head><body></body></html>', {
+      url: 'https://www.youtube.com/',
+      referrer: 'https://www.youtube.com/',
+      userAgent: PO_CONFIG.userAgent
     });
-    const body = await res.json();
-    return body[0];
+    this._applyDomGlobals(this._dom);
+
+    logger('debug', 'PoToken', 'Fetching attestation challenge...');
+    const challengeResponse = await this.getAttestationChallenge(this.visitorData);
+    if (!challengeResponse.bg_challenge) throw new Error('Could not get challenge');
+
+    const interpreterUrl =
+      challengeResponse.bg_challenge.interpreter_url.private_do_not_access_or_else_trusted_resource_url_wrapped_value;
+
+    logger('debug', 'PoToken', `Fetching interpreter from: ${interpreterUrl}`);
+    const bgScriptResponse = await fetch(`https:${interpreterUrl}`);
+    const interpreterJavascript = await bgScriptResponse.text();
+    if (!interpreterJavascript) throw new Error('Could not load BotGuard VM');
+
+    new Function(interpreterJavascript)();
+
+    logger('debug', 'PoToken', 'Creating BotGuard client...');
+    this.botguard = await BotGuardClient.create({
+      program: challengeResponse.bg_challenge.program,
+      globalName: challengeResponse.bg_challenge.global_name,
+      globalObj: globalThis
+    });
+
+    logger('debug', 'PoToken', 'Generating snapshot and creating minter...');
+    const webPoSignalOutput = [];
+    const botguardResponse = await this.botguard.snapshot({ webPoSignalOutput });
+
+    const requestKey = 'O43z0dpjhgX20SCx4KAo';
+    const integrityTokenResponse = await fetch(buildURL('GenerateIT', true), {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json+protobuf',
+        'x-goog-api-key': PO_CONFIG.apiKey,
+        'x-user-agent': 'grpc-web-javascript/0.1',
+        'user-agent': PO_CONFIG.userAgent
+      },
+      body: JSON.stringify([requestKey, botguardResponse])
+    });
+
+    const response = await integrityTokenResponse.json();
+    if (typeof response[0] !== 'string') throw new Error('Could not get integrity token');
+
+    this.integrityToken = response[0];
+    logger('debug', 'PoToken', `IntegrityToken retrieved. Length: ${this.integrityToken.length}`);
+
+    this.minter = await WebPoMinter.create(this.integrityToken, webPoSignalOutput);
+    logger('debug', 'PoToken', 'Initialization complete');
   }
 
-  async bindToken(integrityToken, visitorData) {
+  async generate(videoId) {
+    try {
+      logger('debug', 'PoToken', `Generating token for videoId: ${videoId}`);
+
+      await this.initialize();
+
+      const contentPoToken = await this.minter.mintAsWebsafeString(videoId);
+      logger('debug', 'PoToken', `ContentPoToken generated. Length: ${contentPoToken.length}`);
+
+      const legacyPoToken = this.bindToken(this.integrityToken, this.visitorData);
+      logger('debug', 'PoToken', `LegacyPoToken generated. Length: ${legacyPoToken.length}`);
+
+      const entry = {
+        ts: new Date().toISOString(),
+        videoId,
+        visitorData: this.visitorData,
+        poToken: contentPoToken,
+        legacyPoToken,
+        integrityToken: this.integrityToken?.slice(0, 20) + '...'
+      };
+
+      await appendFile(TOKENS_LOG_PATH, JSON.stringify(entry) + '\n').catch(() => {});
+
+      return { poToken: contentPoToken, visitorData: this.visitorData, legacyPoToken };
+    } catch (error) {
+      const errEntry = {
+        ts: new Date().toISOString(),
+        videoId,
+        error: error.message,
+        stack: error.stack
+      };
+
+      logger('error', 'PoToken', `Failed to generate token for ${videoId}: ${error.message}`);
+      await appendFile(TOKENS_LOG_PATH, JSON.stringify(errEntry) + '\n').catch(() => {});
+
+      this.botguard = null;
+      this.minter = null;
+      this._cleanupDom();
+
+      return { poToken: null, visitorData: null, legacyPoToken: null };
+    }
+  }
+
+  bindToken(integrityToken, visitorData) {
     const itBytes = base64ToU8(integrityToken);
     const vdBytes = Buffer.from(visitorData, 'utf8');
+
     const buffer = new Uint8Array(10 + itBytes.length + vdBytes.length);
-    buffer[0] = 0x22; buffer[1] = buffer.length - 2;
+    buffer[0] = 0x22;
+    buffer[1] = buffer.length - 2;
+
     buffer.set([0x5a, 0xb3, 0x00, 0x01], 2);
-    new DataView(buffer.buffer, 6, 4).setUint32(0, Math.floor(Date.now() / 1000), false);
-    buffer.set(itBytes, 10); buffer.set(vdBytes, 10 + itBytes.length);
+    new DataView(buffer.buffer, 6, 4).setUint32(0, (Date.now() / 1000) | 0, false);
+
+    buffer.set(itBytes, 10);
+    buffer.set(vdBytes, 10 + itBytes.length);
+
     const payload = buffer.subarray(2);
     for (let i = 2; i < payload.length; i++) payload[i] ^= i % 2 === 0 ? 0x5a : 0xb3;
-    return Buffer.from(buffer).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+    return u8ToBase64(buffer, true);
+  }
+
+  async generateStreamingToken() {
+    try {
+      await this.initialize();
+      const sessionPoToken = await this.minter.mintAsWebsafeString(this.visitorData);
+      logger('debug', 'PoToken', `StreamingPoToken generated. Length: ${sessionPoToken.length}`);
+      return sessionPoToken;
+    } catch (error) {
+      logger('error', 'PoToken', `Failed to generate streaming token: ${error.message}`);
+      this.botguard = null;
+      this.minter = null;
+      this._cleanupDom();
+      return null;
+    }
+  }
+
+  generateColdStartToken(visitorData) {
+    try {
+      const identifier = visitorData || this.visitorData;
+      const encodedIdentifier = textEncoder.encode(identifier);
+      if (encodedIdentifier.length > 118) throw new Error('Content binding is too long.');
+
+      const ts = (Date.now() / 1000) | 0;
+      const k0 = (Math.random() * 256) | 0;
+      const k1 = (Math.random() * 256) | 0;
+
+      const packet = new Uint8Array(10 + encodedIdentifier.length);
+      packet[0] = 34;
+      packet[1] = 8 + encodedIdentifier.length;
+
+      packet[2] = k0;
+      packet[3] = k1;
+      packet[4] = 0;
+      packet[5] = 1;
+      packet[6] = (ts >>> 24) & 255;
+      packet[7] = (ts >>> 16) & 255;
+      packet[8] = (ts >>> 8) & 255;
+      packet[9] = ts & 255;
+
+      packet.set(encodedIdentifier, 10);
+
+      const payload = packet.subarray(2);
+      for (let i = 2; i < payload.length; i++) payload[i] ^= payload[i & 1];
+
+      return u8ToBase64(packet, true);
+    } catch (error) {
+      logger('error', 'PoToken', `Failed to generate cold start token: ${error.message}`);
+      return null;
+    }
+  }
+
+  reset() {
+    logger('debug', 'PoToken', 'Resetting PoTokenManager state');
+    this.botguard = null;
+    this.minter = null;
+    this.visitorData = null;
+    this.integrityToken = null;
+    this._cleanupDom();
   }
 }
+
+export const poTokenManager = new PoTokenManager();

--- a/src/sources/youtube/protor.js
+++ b/src/sources/youtube/protor.js
@@ -9,42 +9,39 @@ export class ProtoWriter {
     }
     writeTag(fieldNumber, wireType) { this.writeVarint((fieldNumber << 3) | wireType); }
     writeString(fieldNumber, str) {
-        if (str === undefined || str === null || str === "") return;
+        if (!str) return; // Canonical: omit "", null, undefined
         const buf = Buffer.from(str, 'utf8');
         this.writeTag(fieldNumber, 2);
         this.writeVarint(buf.length);
         this.chunks.push(buf);
     }
     writeBytes(fieldNumber, buffer) {
-        if (buffer === undefined || buffer === null || buffer.length === 0) return;
+        if (!buffer || buffer.length === 0) return; // Canonical: omit
         if (typeof buffer === 'string') {
-            try {
-                buffer = base64ToU8(buffer);
-            } catch (e) {
-                buffer = Buffer.from(buffer, 'utf8');
-            }
+            try { buffer = base64ToU8(buffer); } catch (e) { buffer = Buffer.from(buffer, 'utf8'); }
         }
         this.writeTag(fieldNumber, 2);
         this.writeVarint(buffer.length);
         this.chunks.push(buffer);
     }
     writeInt32(fieldNumber, value) {
-        if (value === undefined || value === null) return;
+        if (!value) return; // Canonical: omit 0, null, undefined
         this.writeTag(fieldNumber, 0);
         this.writeVarint(value);
     }
     writeInt64(fieldNumber, value) {
-        if (value === undefined || value === null) return;
+        // playerTimeMs is often "0" as string or 0 as number
+        if (!value || value === "0") return; // Canonical: omit 0
         this.writeTag(fieldNumber, 0);
         this.writeVarint(value);
     }
     writeBool(fieldNumber, value) {
-        if (value === undefined || value === null || value === false) return;
+        if (!value) return; // Canonical: omit false
         this.writeTag(fieldNumber, 0);
         this.writeVarint(1);
     }
     writeFloat(fieldNumber, value) {
-        if (value === undefined || value === null || value === 0) return;
+        if (!value) return; // Canonical: omit 0
         this.writeTag(fieldNumber, 5);
         const buf = Buffer.alloc(4);
         buf.writeFloatLE(value);
@@ -74,7 +71,7 @@ export class ProtoReader {
     readVarint() {
         let result = 0n, shift = 0n;
         while (true) {
-            if (this.pos >= this.buffer.length) return result; 
+            if (this.pos >= this.buffer.length) return result;
             const b = this.buffer[this.pos++];
             result |= BigInt(b & 0x7F) << shift;
             shift += 7n;
@@ -114,8 +111,9 @@ export class ProtoReader {
 export const FormatId = {
     encode(msg, writer) {
         writer.writeInt32(1, msg.itag);
-        writer.writeInt64(2, msg.lastModified || msg.last_modified || 0);
+        writer.writeInt64(2, msg.lastModified || msg.last_modified);
         writer.writeString(3, msg.xtags);
+        return writer;
     },
     decode(reader, len) {
         const end = reader.pos + len;
@@ -134,15 +132,19 @@ export const FormatId = {
 
 export const ClientAbrState = {
     encode(msg, writer) {
-        writer.writeInt64(28, msg.playerTimeMs);
-        writer.writeInt32(40, msg.enabledTrackTypesBitfield);
-        writer.writeString(69, msg.audioTrackId);
-        writer.writeInt32(21, msg.stickyResolution);
-        writer.writeBool(46, msg.drcEnabled);
-        writer.writeInt32(34, msg.visibility);
-        writer.writeFloat(35, msg.playbackRate || 1.0);
-        writer.writeBool(22, msg.clientViewportIsFlexible);
         writer.writeInt32(16, msg.lastManualSelectedResolution);
+        writer.writeInt32(21, msg.stickyResolution);
+        writer.writeBool(22, msg.clientViewportIsFlexible);
+        writer.writeInt64(23, msg.bandwidthEstimate);
+        writer.writeInt64(28, msg.playerTimeMs);
+        writer.writeInt32(34, msg.visibility);
+        writer.writeFloat(35, msg.playbackRate);
+        writer.writeInt64(39, msg.timeSinceLastActionMs);
+        writer.writeInt32(40, msg.enabledTrackTypesBitfield);
+        writer.writeInt64(44, msg.playerState);
+        writer.writeBool(46, msg.drcEnabled);
+        writer.writeString(69, msg.audioTrackId);
+        return writer;
     }
 };
 
@@ -150,6 +152,7 @@ export const ClientInfo = {
     encode(msg, writer) {
         writer.writeInt32(16, msg.clientName);
         writer.writeString(17, msg.clientVersion);
+        return writer;
     }
 };
 
@@ -157,44 +160,32 @@ export const VideoPlaybackAbrRequest = {
     encode(msg) {
         const writer = new ProtoWriter();
         if (msg.clientAbrState) {
-            const w = new ProtoWriter();
-            ClientAbrState.encode(msg.clientAbrState, w);
-            writer.writeMessage(1, w);
+            writer.writeMessage(1, ClientAbrState.encode(msg.clientAbrState, new ProtoWriter()));
         }
         if (msg.selectedFormatIds) {
             for (const f of msg.selectedFormatIds) {
-                const w = new ProtoWriter();
-                FormatId.encode(f, w);
-                writer.writeMessage(2, w);
+                writer.writeMessage(2, FormatId.encode(f, new ProtoWriter()));
             }
         }
         if (msg.bufferedRanges) {
             for (const r of msg.bufferedRanges) {
-                const w = new ProtoWriter();
-                BufferedRange.encode(r, w);
-                writer.writeMessage(3, w);
+                writer.writeMessage(3, BufferedRange.encode(r, new ProtoWriter()));
             }
         }
-        // Field 4 (playerTimeMs) is not sent by googlevideo's SABR implementation; keep timing only in clientAbrState.
+        writer.writeInt64(4, msg.playerTimeMs);
         writer.writeBytes(5, msg.videoPlaybackUstreamerConfig);
         if (msg.preferredAudioFormatIds) {
             for (const f of msg.preferredAudioFormatIds) {
-                const w = new ProtoWriter();
-                FormatId.encode(f, w);
-                writer.writeMessage(16, w);
+                writer.writeMessage(16, FormatId.encode(f, new ProtoWriter()));
             }
         }
         if (msg.preferredVideoFormatIds) {
             for (const f of msg.preferredVideoFormatIds) {
-                const w = new ProtoWriter();
-                FormatId.encode(f, w);
-                writer.writeMessage(17, w);
+                writer.writeMessage(17, FormatId.encode(f, new ProtoWriter()));
             }
         }
         if (msg.streamerContext) {
-            const w = new ProtoWriter();
-            StreamerContext.encode(msg.streamerContext, w);
-            writer.writeMessage(19, w);
+            writer.writeMessage(19, StreamerContext.encode(msg.streamerContext, new ProtoWriter()));
         }
         return writer.finish();
     }
@@ -202,9 +193,10 @@ export const VideoPlaybackAbrRequest = {
 
 export const TimeRange = {
     encode(msg, writer) {
-        writer.writeInt64(1, msg.startTicks || 0);
-        writer.writeInt64(2, msg.durationTicks || 0);
-        writer.writeInt32(3, msg.timescale || 0);
+        writer.writeInt64(1, msg.startTicks);
+        writer.writeInt64(2, msg.durationTicks);
+        writer.writeInt32(3, msg.timescale);
+        return writer;
     },
     decode(reader, len) {
         const end = reader.pos + len;
@@ -224,19 +216,16 @@ export const TimeRange = {
 export const BufferedRange = {
     encode(msg, writer) {
         if (msg.formatId) {
-            const w = new ProtoWriter();
-            FormatId.encode(msg.formatId, w);
-            writer.writeMessage(1, w);
+            writer.writeMessage(1, FormatId.encode(msg.formatId, new ProtoWriter()));
         }
-        writer.writeInt64(2, msg.startTimeMs || 0);
-        writer.writeInt64(3, msg.durationMs || 0);
-        writer.writeInt32(4, msg.startSegmentIndex || 0);
-        writer.writeInt32(5, msg.endSegmentIndex || 0);
+        writer.writeInt64(2, msg.startTimeMs);
+        writer.writeInt64(3, msg.durationMs);
+        writer.writeInt32(4, msg.startSegmentIndex);
+        writer.writeInt32(5, msg.endSegmentIndex);
         if (msg.timeRange) {
-            const w = new ProtoWriter();
-            TimeRange.encode(msg.timeRange, w);
-            writer.writeMessage(6, w);
+            writer.writeMessage(6, TimeRange.encode(msg.timeRange, new ProtoWriter()));
         }
+        return writer;
     }
 };
 
@@ -249,18 +238,22 @@ export const MediaHeader = {
             const field = tag >>> 3;
             if (field === 1) msg.headerId = Number(reader.readVarint());
             else if (field === 3) msg.itag = Number(reader.readVarint());
+            else if (field === 4) msg.lmt = reader.readVarint().toString();
             else if (field === 5) msg.xtags = reader.readString();
             else if (field === 8) msg.isInitSeg = Boolean(reader.readVarint());
             else if (field === 9) msg.sequenceNumber = Number(reader.readVarint());
             else if (field === 11) msg.startMs = reader.readVarint().toString();
             else if (field === 12) msg.durationMs = reader.readVarint().toString();
             else if (field === 13) {
-                msg.formatId = FormatId.decode(reader, Number(reader.readVarint()));
-                msg.itag = msg.formatId.itag;
-                msg.xtags = msg.formatId.xtags;
+                const subLen = Number(reader.readVarint());
+                msg.formatId = FormatId.decode(reader, subLen);
+                msg.itag = msg.formatId.itag || msg.itag;
+                msg.xtags = msg.formatId.xtags || msg.xtags;
             } else if (field === 14) msg.contentLength = reader.readVarint().toString();
-            else if (field === 15) msg.timeRange = TimeRange.decode(reader, Number(reader.readVarint()));
-            else reader.skip(tag & 7);
+            else if (field === 15) {
+                const subLen = Number(reader.readVarint());
+                msg.timeRange = TimeRange.decode(reader, subLen);
+            } else reader.skip(tag & 7);
         }
         return msg;
     }
@@ -275,7 +268,7 @@ export const FormatInitializationMetadata = {
             const field = tag >>> 3;
             if (field === 2) {
                 msg.formatId = FormatId.decode(reader, Number(reader.readVarint()));
-                msg.itag = msg.formatId.itag; 
+                msg.itag = msg.formatId.itag;
             } else if (field === 4) msg.endSegmentNumber = reader.readVarint().toString();
             else if (field === 5) msg.mimeType = reader.readString();
             else if (field === 9) msg.durationUnits = reader.readVarint().toString();
@@ -485,15 +478,11 @@ export const RequestCancellationPolicy = {
 export const StreamerContext = {
     encode(msg, writer) {
         if (msg.clientInfo) {
-            const w = new ProtoWriter();
-            ClientInfo.encode(msg.clientInfo, w);
-            writer.writeMessage(1, w);
+            writer.writeMessage(1, ClientInfo.encode(msg.clientInfo, new ProtoWriter()));
         }
         writer.writeBytes(2, msg.poToken);
         if (msg.playbackCookie) {
-            const w = new ProtoWriter();
-            w.writeBytes(1, msg.playbackCookie);
-            writer.writeMessage(3, w);
+            writer.writeBytes(3, msg.playbackCookie);
         }
         if (msg.sabrContexts) {
             for (const ctx of msg.sabrContexts) {
@@ -508,6 +497,7 @@ export const StreamerContext = {
                 writer.writeInt32(6, type);
             }
         }
+        return writer;
     }
 };
 
@@ -550,4 +540,52 @@ export function concatenateChunks(chunks) {
         offset += chunk.length;
     }
     return result;
+}
+
+export class UMPWriter {
+    constructor() {
+        this.chunks = [];
+    }
+
+    write(partType, partData) {
+        this.writeVarInt(partType);
+        this.writeVarInt(partData.length);
+        this.chunks.push(partData);
+    }
+
+    writeVarInt(value) {
+        if (value < 0) throw new Error('VarInt value cannot be negative.');
+
+        if (value < 128) {
+            this.chunks.push(new Uint8Array([value]));
+        } else if (value < 16384) {
+            this.chunks.push(new Uint8Array([
+                (value & 0x3F) | 0x80,
+                value >> 6
+            ]));
+        } else if (value < 2097152) {
+            this.chunks.push(new Uint8Array([
+                (value & 0x1F) | 0xC0,
+                (value >> 5) & 0xFF,
+                value >> 13
+            ]));
+        } else if (value < 268435456) {
+            this.chunks.push(new Uint8Array([
+                (value & 0x0F) | 0xE0,
+                (value >> 4) & 0xFF,
+                (value >> 12) & 0xFF,
+                value >> 20
+            ]));
+        } else {
+            const data = new Uint8Array(5);
+            const view = new DataView(data.buffer);
+            data[0] = 0xF0;
+            view.setUint32(1, value, true);
+            this.chunks.push(data);
+        }
+    }
+
+    finish() {
+        return concatenateChunks(this.chunks);
+    }
 }

--- a/src/sources/youtube/sabr.js
+++ b/src/sources/youtube/sabr.js
@@ -4,22 +4,23 @@ import path from 'node:path';
 import { appendFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { logger, makeRequest } from '../../utils.js';
-import { PoTokenManager } from './potoke.js';
-import { 
-    UMPPartId, 
-    FormatInitializationMetadata, 
-    SabrError, 
-    SabrRedirect, 
-    StreamProtectionStatus, 
-    MediaHeader, 
-    NextRequestPolicy, 
+import { poTokenManager } from './potoke.js';
+import {
+    UMPPartId,
+    FormatInitializationMetadata,
+    SabrError,
+    SabrRedirect,
+    StreamProtectionStatus,
+    MediaHeader,
+    NextRequestPolicy,
     PlaybackStartPolicy,
     RequestIdentifier,
     RequestCancellationPolicy,
-    SabrContextUpdate, 
-    SabrContextSendingPolicy, 
-    VideoPlaybackAbrRequest, 
+    SabrContextUpdate,
+    SabrContextSendingPolicy,
+    VideoPlaybackAbrRequest,
     ProtoReader,
+    UMPWriter,
     base64ToU8,
     concatenateChunks
 } from './protor.js';
@@ -87,30 +88,32 @@ class CompositeBuffer {
         this.chunks = [];
         this.currentChunkOffset = 0;
         this.currentChunkIndex = 0;
-        this.currentDataView = undefined;
         this.totalLength = 0;
+        this.currentDataView = undefined;
         chunks.forEach((chunk) => this.append(chunk));
     }
     append(chunk) {
         if (chunk instanceof Uint8Array) {
+            if (chunk.length === 0) return;
             this.chunks.push(chunk);
             this.totalLength += chunk.length;
-        } else {
+        } else if (chunk instanceof CompositeBuffer) {
             chunk.chunks.forEach((c) => this.append(c));
         }
+        this.currentDataView = undefined;
     }
     split(position) {
         const extractedBuffer = new CompositeBuffer();
         const remainingBuffer = new CompositeBuffer();
         let remainingPos = position;
-        
+
         for(const chunk of this.chunks) {
             if (remainingPos >= chunk.length) {
                 extractedBuffer.append(chunk);
                 remainingPos -= chunk.length;
             } else if (remainingPos > 0) {
-                extractedBuffer.append(new Uint8Array(chunk.buffer, chunk.byteOffset, remainingPos));
-                remainingBuffer.append(new Uint8Array(chunk.buffer, chunk.byteOffset + remainingPos, chunk.length - remainingPos));
+                extractedBuffer.append(chunk.subarray(0, remainingPos));
+                remainingBuffer.append(chunk.subarray(remainingPos));
                 remainingPos = 0;
             } else {
                 remainingBuffer.append(chunk);
@@ -123,9 +126,10 @@ class CompositeBuffer {
         this.focus(position);
         return this.chunks[this.currentChunkIndex][position - this.currentChunkOffset];
     }
+    getLength() { return this.totalLength; }
     focus(position) {
         if (position < this.currentChunkOffset) this.resetFocus();
-        while (this.currentChunkOffset + this.chunks[this.currentChunkIndex].length <= position && this.currentChunkIndex < this.chunks.length - 1) {
+        while (this.currentChunkIndex < this.chunks.length && this.currentChunkOffset + this.chunks[this.currentChunkIndex].length <= position) {
             this.currentChunkOffset += this.chunks[this.currentChunkIndex].length;
             this.currentChunkIndex += 1;
         }
@@ -139,20 +143,28 @@ class UmpReader {
     read(handlePart) {
         while (true) {
             let offset = 0;
-            const [partType, newOffset] = this.readVarInt(offset);
-            offset = newOffset;
-            const [partSize, finalOffset] = this.readVarInt(offset);
-            offset = finalOffset;
-            if (partType < 0 || partSize < 0) break;
-            if (!this.compositeBuffer.canReadBytes(offset, partSize)) {
-                if (!this.compositeBuffer.canReadBytes(offset, 1)) break;
-                return { type: partType, size: partSize, data: this.compositeBuffer };
+            const [partType, nextOffset] = this.readVarInt(offset);
+            if (partType < 0) break;
+
+            const [partSize, finalOffset] = this.readVarInt(nextOffset);
+            if (partSize < 0) break;
+
+            if (!this.compositeBuffer.canReadBytes(finalOffset, partSize)) {
+                const split = this.compositeBuffer.split(finalOffset);
+                return {
+                    type: partType,
+                    size: partSize,
+                    headerSize: finalOffset,
+                    data: split.remainingBuffer,
+                    incomplete: true
+                };
             }
-            const splitResult = this.compositeBuffer.split(offset).remainingBuffer.split(partSize);
-            offset = 0;
+
+            const splitResult = this.compositeBuffer.split(finalOffset).remainingBuffer.split(partSize);
             handlePart({ type: partType, size: partSize, data: splitResult.extractedBuffer });
             this.compositeBuffer = splitResult.remainingBuffer;
         }
+        return undefined;
     }
     readVarInt(offset) {
         let byteLength;
@@ -161,6 +173,7 @@ class UmpReader {
             byteLength = firstByte < 128 ? 1 : firstByte < 192 ? 2 : firstByte < 224 ? 3 : firstByte < 240 ? 4 : 5;
         } else { byteLength = 0; }
         if (byteLength < 1 || !this.compositeBuffer.canReadBytes(offset, byteLength)) return [-1, offset];
+
         let value;
         switch (byteLength) {
             case 1: value = this.compositeBuffer.getUint8(offset++); break;
@@ -228,26 +241,58 @@ export class SabrStream extends PassThrough {
         this.requestNumber = 0;
         this.mediaHeadersProcessed = false;
         this._aborted = false;
-        
-        this.poToken = config.poToken; 
+        this.formatSequenceCounters = new Map(); // itag -> lastSeq
+        this.downloadedSegmentsByItag = new Map(); // itag -> Map<segNum, seg>
+
+        this.poToken = config.poToken;
         this.visitorData = config.visitorData;
-        
+
         this.serverAbrStreamingUrl = config.serverAbrStreamingUrl;
+        if (this.serverAbrStreamingUrl) {
+            const url = new URL(this.serverAbrStreamingUrl);
+            url.searchParams.set('alr', 'yes');
+            url.searchParams.set('ump', '1');
+            url.searchParams.set('srfvp', '1');
+            this.serverAbrStreamingUrl = url.toString();
+        }
         this.videoPlaybackUstreamerConfig = config.videoPlaybackUstreamerConfig;
         this.clientInfo = config.clientInfo;
         this.formatIds = config.formats || [];
         this.startTime = config.startTime || 0;
         this.positionCallback = config.positionCallback;
         this.userAgent = config.userAgent || USER_AGENT;
-        
+
         this.cachedBufferedRanges = [];
-        
+
+        this.totalLength = 0;
+        this.totalDurationMs = 0;
         this.totalDownloadedMs = 0;
+        this.virtualPlayerTimeMs = 0;
+        this.lastVirtualAdvanceAt = 0;
+        this.lastIterationAt = Date.now();
+        this.lastReportedPlayerTimeMs = 0;
+        this.partialPart = undefined;
+
+        this.pendingRangesHeaders = new Map();
+        this.cachedBufferedRanges = null;
+        this.lastReportedRanges = new Set();
 
         this.enableTrafficLog = true;
         this.trafficLogPath = path.join(process.cwd(), 'sabr_traffic.jsonl');
         this.enableTrafficDump = true;
         this.trafficDumpMaxBytes = 64 * 1024;
+
+        this.noMediaStreak = 0;
+        this.abortController = new AbortController();
+
+        if (typeof this.poToken === 'string') {
+            try {
+                this.poToken = base64ToU8(this.poToken);
+            } catch (e) {
+                logger('error', 'SABR', `Failed to decode PO token: ${e.message}`);
+                this.poToken = null;
+            }
+        }
     }
 
     logTraffic(entry) {
@@ -267,9 +312,44 @@ export class SabrStream extends PassThrough {
 
     async loop(audioFormat) {
         try {
+            if (this.lastVirtualAdvanceAt === 0) this.lastVirtualAdvanceAt = Date.now();
             while (!this._aborted && !this.destroyed) {
                 const now = Date.now();
-                const reportedPlayerTime = (this.config.startTime || 0) + this.totalDownloadedMs;
+                const prevPlayerTime = this.virtualPlayerTimeMs;
+
+                if (this.totalDownloadedMs > this.virtualPlayerTimeMs) {
+                    if (this.lastVirtualAdvanceAt > 0) {
+                        this.virtualPlayerTimeMs += (now - this.lastVirtualAdvanceAt);
+                    }
+                    this.lastVirtualAdvanceAt = now;
+                } else {
+                    if (this.totalDownloadedMs > 0) {
+                        if (this.lastVirtualAdvanceAt > 0) {
+                           const advance = (now - this.lastVirtualAdvanceAt);
+                           this.virtualPlayerTimeMs = Math.min(this.virtualPlayerTimeMs + advance, this.totalDownloadedMs);
+                        }
+                        this.lastVirtualAdvanceAt = now;
+                    }
+                }
+
+                if (Math.floor(this.virtualPlayerTimeMs / 1000) !== Math.floor(prevPlayerTime / 1000)) {
+                    logger('debug', 'SABR', `Tracking: downloaded=${Math.floor(this.totalDownloadedMs)}ms virtualPlayerTime=${Math.floor(prevPlayerTime)}ms -> ${Math.floor(this.virtualPlayerTimeMs)}ms`);
+                }
+
+                this.lastIterationAt = now;
+
+                let reportedPlayerTime = Math.floor(this.virtualPlayerTimeMs);
+
+                this.lastReportedPlayerTimeMs = reportedPlayerTime;
+
+                if (this.readableLength > MAX_BUFFER_BYTES) {
+                    await wait(250);
+                    continue;
+                }
+
+                if (this.mediaHeadersProcessed && this.positionCallback) {
+                    this.positionCallback(reportedPlayerTime);
+                }
 
                 if (this.lastRequestAt) {
                     const since = now - this.lastRequestAt;
@@ -277,17 +357,42 @@ export class SabrStream extends PassThrough {
                 }
                 this.lastRequestAt = Date.now();
 
-                await this.fetchAndProcessSegments({
-                        playerTimeMs: reportedPlayerTime,
+                try {
+                    await this.fetchAndProcessSegments({
+                        playerTimeMs: Math.floor(this.totalDownloadedMs),
+                        bandwidthEstimate: 15000000,
                         enabledTrackTypesBitfield: 1,
                         audioTrackId: audioFormat.audioTrackId || "",
-                        stickyResolution: 360,
-                        drcEnabled: false,
+                        playerState: 1n,
                         visibility: 1,
                         playbackRate: 1.0,
-                        clientViewportIsFlexible: false,
-                        lastManualSelectedResolution: undefined
+                        stickyResolution: 1080,
+                        lastManualSelectedResolution: 1080,
+                        clientViewportIsFlexible: false
                     }, audioFormat);
+                } catch (e) {
+                    if (this._aborted || this.destroyed) break;
+
+                    if (e.message.includes('sabr.malformed_config') || e.message.includes('sabr.media_serving_enforcement_id_error')) {
+                        logger('warn', 'SABR', `Recoverable error detected: ${e.message}. Triggering recovery signal...`);
+
+                        if (e.message.includes('media_serving_enforcement_id_error')) {
+                            logger('warn', 'SABR', 'Enforcement ID error detected. Clearing SABR contexts to force fresh state.');
+                            this.sabrContexts.clear();
+                            this.activeSabrContextTypes.clear();
+                        }
+
+                        this.emit('stall');
+
+                        const currentRn = this.requestNumber;
+                        while (this.requestNumber === currentRn && !this._aborted && !this.destroyed) {
+                            await wait(500);
+                        }
+                        continue;
+                    }
+
+                    throw e;
+                }
 
                 if (!this.nextRequestPolicy?.backoffTimeMs && this.initializedFormatsMap.size === 0) {
                     await wait(250);
@@ -299,12 +404,58 @@ export class SabrStream extends PassThrough {
     }
 
     destroy(err) {
+        if (this._aborted) return;
         this._aborted = true;
+        this.abortController.abort();
         super.destroy(err);
     }
 
+    updateSession(config) {
+        if (config.serverAbrStreamingUrl) {
+            const url = new URL(config.serverAbrStreamingUrl);
+            url.searchParams.set('alr', 'yes');
+            url.searchParams.set('ump', '1');
+            url.searchParams.set('srfvp', '1');
+            this.serverAbrStreamingUrl = url.toString();
+        }
+        if (config.videoPlaybackUstreamerConfig) {
+            this.videoPlaybackUstreamerConfig = config.videoPlaybackUstreamerConfig;
+        }
+        if (config.poToken) {
+            this.poToken = typeof config.poToken === 'string' ? base64ToU8(config.poToken) : config.poToken;
+        }
+        if (config.playbackCookie) {
+            if (!this.nextRequestPolicy) this.nextRequestPolicy = {};
+            this.nextRequestPolicy.playbackCookie = config.playbackCookie;
+        } else if (this.nextRequestPolicy) {
+            delete this.nextRequestPolicy.playbackCookie;
+        }
+        this.requestNumber = 0;
+        this.noMediaStreak = 0;
+        this.pendingRangesHeaders.clear();
+
+        logger('info', 'SABR', `Session updated. Continuing with RN=${this.requestNumber}, URL=${this.serverAbrStreamingUrl.slice(0, 50)}...`);
+    }
+
+    clearBuffers() {
+        this.initializedFormatsMap.clear();
+        this.downloadedSegmentsByItag.clear();
+        this.formatSequenceCounters.clear();
+        this.partialSegmentQueue.clear();
+
+        this.mediaHeadersProcessed = false;
+        this.pendingRangesHeaders.clear();
+        this.cachedBufferedRanges = null;
+        this.lastReportedRanges.clear();
+
+        this.sabrContexts.clear();
+        this.activeSabrContextTypes.clear();
+
+        logger('info', 'SABR', `Buffers cleared for recovery. Preserving timeline position: ${this.cumulativeDownloadedMs}ms`);
+    }
+
     decodePart(part, decoder) {
-        try { 
+        try {
             const data = concatenateChunks(part.data.chunks);
             return decoder.decode(new ProtoReader(data), data.length);
         } catch(e) { return undefined; }
@@ -352,18 +503,24 @@ export class SabrStream extends PassThrough {
         if (!m) return;
         const k = FormatKeyUtils.fromFormatInitializationMetadata(m);
         if (!this.initializedFormatsMap.has(k)) {
-            this.initializedFormatsMap.set(k, { formatInitializationMetadata: m, downloadedSegments: new Map() });
+            this.initializedFormatsMap.set(k, { formatInitializationMetadata: m });
             logger('debug', 'SABR', `Format init: key=${k} mime=${m.mimeType || ''} endSeg=${m.endSegmentNumber || ''}`);
         }
     }
 
-    handleSabrError(part) { 
-        const err = this.decodePart(part, SabrError); 
-        if(err) this.emit('error', new Error(`SABR Error: ${err.code} ${err.type}`)); 
+    handleSabrError(part) {
+        const err = this.decodePart(part, SabrError);
+        if (err) {
+            const error = new Error(`SABR Error: ${err.code} ${err.type}`);
+            error.code = err.code;
+            error.type = err.type;
+            if (this._aborted || this.destroyed) return;
+            throw error;
+        }
     }
 
-    handleSabrRedirect(part) { 
-        const red = this.decodePart(part, SabrRedirect); 
+    handleSabrRedirect(part) {
+        const red = this.decodePart(part, SabrRedirect);
         if(red && red.url) {
             this.serverAbrStreamingUrl = red.url;
         }
@@ -386,8 +543,42 @@ export class SabrStream extends PassThrough {
             return;
         }
 
-        const level = status.status === 2 ? 'debug' : 'warn';
+        if (status.status === 2) {
+            logger('warn', 'SABR', `Stream Protection Status: ${status.status} (Limited Playback). Triggering token refresh...`);
+            poTokenManager.reset();
+            this.emit('stall');
+            return;
+        }
+
+        const level = 'warn';
         logger(level, 'SABR', `Stream Protection Status: ${status.status}`);
+    }
+
+    handleMediaPartial(buffer, headerId, isFirstChunk) {
+        const s = this.partialSegmentQueue.get(headerId);
+        if (s) {
+
+            let dataToPush = buffer;
+
+            if (isFirstChunk) {
+                if (buffer.getLength() > 1) {
+                    dataToPush = buffer.split(1).remainingBuffer;
+                } else if (buffer.getLength() === 1) {
+                    return;
+                }
+            }
+
+            const bytes = dataToPush.getLength();
+            s.loadedBytes = (s.loadedBytes || 0) + bytes;
+
+            for (const c of dataToPush.chunks) this.push(c);
+
+            if (bytes > 0) {
+               // logger('debug', 'SABR', `d: ${bytes}`); // Verbose
+            }
+        } else {
+            // logger('trace', 'SABR', `Partial media for unknown headerId: ${headerId}`);
+        }
     }
 
     handleMedia(part) {
@@ -395,7 +586,16 @@ export class SabrStream extends PassThrough {
         const s = this.partialSegmentQueue.get(headerId);
         if (s) {
             const d = part.data.split(1).remainingBuffer;
-            for (const c of d.chunks) s.bufferedChunks.push(c);
+            const bytes = d.totalLength;
+            s.loadedBytes = (s.loadedBytes || 0) + bytes;
+
+            for (const c of d.chunks) this.push(c);
+
+            if (bytes > 0) {
+               logger('debug', 'SABR', `Media data: id=${headerId} bytes=${bytes} total=${s.loadedBytes}/${s.mediaHeader?.contentLength || '?'}`);
+            }
+        } else {
+            logger('trace', 'SABR', `Media data for unknown headerId: ${headerId}`);
         }
     }
 
@@ -403,21 +603,44 @@ export class SabrStream extends PassThrough {
         const h = this.decodePart(part, MediaHeader);
         if (h) {
             const key = FormatKeyUtils.fromMediaHeader(h);
-            const segmentNumber = h.isInitSeg ? 0 : (h.sequenceNumber || 0);
-            
+            const headerId = h.headerId || 0;
+
+            let segmentNumber = h.sequenceNumber;
+            if (h.isInitSeg) {
+                segmentNumber = 0;
+            } else if (segmentNumber === undefined || segmentNumber === 0) {
+                const count = (this.formatSequenceCounters.get(h.itag) || 0) + 1;
+                this.formatSequenceCounters.set(h.itag, count);
+                segmentNumber = count;
+            } else {
+                this.formatSequenceCounters.set(h.itag, segmentNumber);
+            }
+
             if (!h.durationMs || h.durationMs === "0") {
                 if (h.timeRange && h.timeRange.timescale > 0) {
-                    h.durationMs = Math.ceil((parseInt(h.timeRange.durationTicks || '0') / h.timeRange.timescale) * 1000).toString();
+                    h.durationMs = Math.ceil((Number(h.timeRange.durationTicks || 0n) / h.timeRange.timescale) * 1000).toString();
                 }
             }
 
-            this.partialSegmentQueue.set(h.headerId || 0, { 
-                formatIdKey: key, 
+            const mediaHeader = h;
+            const formatIdKey = key;
+
+            if (!this.pendingRangesHeaders.has(formatIdKey)) {
+                this.pendingRangesHeaders.set(formatIdKey, []);
+            }
+            this.pendingRangesHeaders.get(formatIdKey).push(mediaHeader);
+
+            logger('debug', 'SABR', `MediaHeader: id=${headerId} itag=${h.itag} seq=${segmentNumber} dur=${h.durationMs}ms`);
+
+            this.partialSegmentQueue.set(headerId, {
+                formatIdKey: key,
                 segmentNumber,
-                mediaHeader: h, 
+                mediaHeader: h,
                 durationMs: h.durationMs,
-                bufferedChunks: [] 
+                loadedBytes: 0
             });
+        } else {
+            logger('warn', 'SABR', 'Failed to decode MediaHeader');
         }
     }
 
@@ -425,45 +648,56 @@ export class SabrStream extends PassThrough {
         const id = part.data.getUint8(0);
         const s = this.partialSegmentQueue.get(id);
         if (s) {
-            const f = this.initializedFormatsMap.get(s.formatIdKey);
-            if (f) {
-                const totalBytes = s.bufferedChunks.reduce((acc, c) => acc + c.length, 0);
+            logger('debug', 'SABR', `MediaEnd: id=${id} seq=${s.segmentNumber} totalBytes=${s.loadedBytes}`);
 
-                if (f.downloadedSegments.has(s.segmentNumber)) {
-                    logger('warn', 'SABR', `Ignoring duplicate segment ${s.segmentNumber} for format ${s.formatIdKey}`);
-                } else {
-                    for (const c of s.bufferedChunks) this.push(c);
-                    if (s.durationMs && !this.positionCallback) this.startTime += parseInt(s.durationMs);
-                    
-                    if (s.durationMs) {
-                        this.totalDownloadedMs += parseInt(s.durationMs, 10);
-                    }
+            const itag = s.mediaHeader?.itag || s.mediaHeader?.formatId?.itag;
+
+            let segmentDuration = 0;
+            if (s.durationMs) {
+                segmentDuration = Number(s.durationMs);
+            } else if (s.mediaHeader?.timeRange && s.mediaHeader.timeRange.timescale > 0) {
+                segmentDuration = Math.ceil((Number(s.mediaHeader.timeRange.durationTicks || 0n) / s.mediaHeader.timeRange.timescale) * 1000);
+            }
+
+            if (segmentDuration > 0) {
+                this.totalDownloadedMs += segmentDuration;
+                this.mediaHeadersProcessed = true;
+                logger('debug', 'SABR', `Segment received: itag=${itag} seq=${s.segmentNumber} dur=${segmentDuration}ms totalDownloaded=${Math.floor(this.totalDownloadedMs)}ms`);
+            }
+
+            if (itag) {
+                if (!this.downloadedSegmentsByItag.has(itag)) {
+                    this.downloadedSegmentsByItag.set(itag, new Map());
                 }
-                
-                s.bufferedChunks = [];
+                const segMap = this.downloadedSegmentsByItag.get(itag);
 
-                f.downloadedSegments.set(s.segmentNumber, {
-                    durationMs: s.durationMs,
-                    byteLength: totalBytes,
-                    mediaHeader: s.mediaHeader
-                });
+                if (segMap.has(s.segmentNumber)) {
+                    logger('warn', 'SABR', `Ignoring duplicate segment ${s.segmentNumber} for itag ${itag}`);
+                } else {
+                    const sorted = Array.from(segMap.values()).sort((a, b) => a.endMs - b.endMs);
+                    const newestEndMs = sorted.length > 0 ? sorted[sorted.length - 1].endMs : 0;
 
-                if (!f.lastMediaHeaders) f.lastMediaHeaders = [];
-                f.lastMediaHeaders.push(s.mediaHeader);
-
-                const MAX_SEGMENT_AGE_MS = 600000;
-                let accumulatedDuration = 0;
-                const sortedSegs = Array.from(f.downloadedSegments.keys()).sort((a, b) => b - a);
-                
-                for (const segNum of sortedSegs) {
-                    const seg = f.downloadedSegments.get(segNum);
-                    accumulatedDuration += parseInt(seg.durationMs || '0', 10);
-                    
-                    if (accumulatedDuration > MAX_SEGMENT_AGE_MS) {
-                        f.downloadedSegments.delete(segNum);
+                    let startMs = Number(s.mediaHeader.startMs || 0n);
+                    if (startMs === 0 && s.mediaHeader.timeRange && s.mediaHeader.timeRange.timescale > 0) {
+                        startMs = Number((BigInt(s.mediaHeader.timeRange.startTicks || 0n) * 1000n) / BigInt(s.mediaHeader.timeRange.timescale));
                     }
+                    const endMs = startMs + segmentDuration;
+
+                    segMap.set(s.segmentNumber, {
+                        segmentNumber: s.segmentNumber,
+                        durationMs: segmentDuration,
+                        byteLength: s.loadedBytes || 0,
+                        mediaHeader: s.mediaHeader,
+                        startMs,
+                        endMs
+                    });
+
+                    let maxEdge = this.cumulativeDownloadedMs || 0;
+                    if (endMs > maxEdge) maxEdge = endMs;
+                    this.cumulativeDownloadedMs = maxEdge;
                 }
             }
+
             this.partialSegmentQueue.delete(id);
         }
     }
@@ -509,6 +743,7 @@ export class SabrStream extends PassThrough {
         if (ctx && ctx.type !== undefined && ctx.value?.length) {
             this.sabrContexts.set(ctx.type, ctx);
             if (ctx.sendByDefault) this.activeSabrContextTypes.add(ctx.type);
+            logger('debug', 'SABR', `Received context update type=${ctx.type} len=${ctx.value?.length} sendByDefault=${ctx.sendByDefault}`);
         }
     }
 
@@ -522,7 +757,13 @@ export class SabrStream extends PassThrough {
     }
 
     handleSnackbarMessage(part) {}
-    handleReloadPlayerResponse(part) {}
+    handleReloadPlayerResponse(part) {
+        const reloadContext = this.decodePart(part, ReloadPlaybackContext);
+        if (reloadContext) {
+            logger('warn', 'SABR', `Reload requested by server. Reason: ${reloadContext.reason || 'unknown'}`);
+            this.emit('stall');
+        }
+    }
 
     logDetailedState({ abrState, audioFormat, videoFormat, selectedFormatIds, preferredAudioFormatIds, preferredVideoFormatIds, bufferedRanges, contexts, unsent }) {
         const now = Date.now();
@@ -532,8 +773,8 @@ export class SabrStream extends PassThrough {
         const cookieLen = this.nextRequestPolicy?.playbackCookie?.length || 0;
         const initKeys = Array.from(this.initializedFormatsMap.keys()).slice(0, 5);
 
-        const initAudio = this.getInitializedByFormat(audioFormat);
-        const segs = initAudio?.downloadedSegments ? Array.from(initAudio.downloadedSegments.values()) : [];
+        const segMap = this.downloadedSegmentsByItag.get(audioFormat?.itag);
+        const segs = segMap ? Array.from(segMap.values()) : [];
         const downloadedMs = segs.reduce((sum, s) => sum + parseInt(s.durationMs || '0'), 0);
         const aheadMs = abrState?.playerTimeMs !== undefined ? (downloadedMs - abrState.playerTimeMs) : undefined;
 
@@ -555,38 +796,57 @@ export class SabrStream extends PassThrough {
 
     buildBufferedRanges(vFormat, aFormat) {
         const bufferedRanges = [];
-        const formats = [vFormat, aFormat].filter((f) => f);
+        const formats = [vFormat, aFormat].filter(f => f);
 
         for (const format of formats) {
-            const initialized = this.getInitializedByFormat(format);
-            if (!initialized || !initialized.lastMediaHeaders?.length) continue;
+            const itag = format.itag;
+            const formatIdKey = createKey(itag, format.xtags);
+            const headers = this.pendingRangesHeaders.get(formatIdKey);
 
-            const headers = initialized.lastMediaHeaders;
-            const durationMs = headers.reduce((sum, h) => sum + (parseInt(h.durationMs || '0', 10)), 0);
-            
-            const formatId = initialized.formatInitializationMetadata?.formatId || headers[0].formatId || this.resolveFormatIdForRequest(format);
+            if (!headers || headers.length === 0) continue;
+
+            const durationMs = headers.reduce((sum, h) => sum + parseInt(h.durationMs || '0'), 0);
+            const startH = headers[0];
+            const endH = headers[headers.length - 1];
 
             bufferedRanges.push({
-                formatId,
                 durationMs: durationMs.toString(),
-                startTimeMs: String(headers[0].startMs || '0'),
-                startSegmentIndex: headers[0].isInitSeg ? 0 : (headers[0].sequenceNumber || 0),
-                endSegmentIndex: headers[headers.length - 1].sequenceNumber || 0,
+                formatId: this.resolveFormatIdForRequest(format),
+                startTimeMs: (startH.startMs || "0").toString(),
+                startSegmentIndex: startH.sequenceNumber || 1,
+                endSegmentIndex: endH.sequenceNumber || 1,
                 timeRange: {
-                    durationTicks: durationMs.toString(),
-                    startTicks: headers[0].startMs || '0',
-                    timescale: headers[0].timeRange?.timescale || 1000
+                    durationTicks: (BigInt(durationMs) * BigInt(startH.timeRange?.timescale || 1000) / 1000n).toString(),
+                    startTicks: (startH.startMs || "0").toString(),
+                    timescale: startH.timeRange?.timescale || 1000
                 }
             });
-            initialized.lastMediaHeaders = [];
+
+            this.pendingRangesHeaders.set(formatIdKey, []);
         }
 
         return bufferedRanges;
     }
 
+    finalizeRange(r) {
+
+        return {
+            durationMs: r.durationMs.toString(),
+            formatId: r.formatId,
+            startTimeMs: r.startTimeMs.toString(),
+            startSegmentIndex: r.startSegmentIndex,
+            endSegmentIndex: r.endSegmentIndex,
+            timeRange: {
+                durationTicks: (BigInt(Math.floor(r.durationMs)) * BigInt(r.timescale) / 1000n).toString(),
+                startTicks: r.startTicks.toString(),
+                timescale: r.timescale
+            }
+        };
+    }
+
     async fetchAndProcessSegments(abrState, audioFormat, videoFormat) {
          if (!this.videoPlaybackUstreamerConfig || !this.clientInfo) throw new Error('Missing config');
-         
+
          if (this.nextRequestPolicy?.backoffTimeMs > 0) {
              const backoff = this.nextRequestPolicy.backoffTimeMs;
              logger('warn', 'SABR', `Waiting for backoff: ${backoff}ms`);
@@ -595,16 +855,25 @@ export class SabrStream extends PassThrough {
          }
 
          const formats = [videoFormat, audioFormat].filter(f => f);
+         const formatsInitialized = this.initializedFormatsMap.size > 0;
          const requestFormatIds = formats.map((f) => this.resolveFormatIdForRequest(f)).filter((f) => f);
-         const selectedFormatIds = (this.initializedFormatsMap.size > 0) ? requestFormatIds : [];
 
-         this.cachedBufferedRanges = this.buildBufferedRanges(videoFormat, audioFormat);
+         const selectedFormatIds = formatsInitialized ? requestFormatIds : [];
+
+          if (!this.cachedBufferedRanges) {
+              this.cachedBufferedRanges = this.buildBufferedRanges(videoFormat, audioFormat);
+          }
 
          const contexts = [];
+         const unsent = [];
+
          for (const ctx of this.sabrContexts.values()) {
-             if (this.activeSabrContextTypes.has(ctx.type)) contexts.push({ type: ctx.type, value: ctx.value });
+             if (this.activeSabrContextTypes.has(ctx.type)) {
+                 contexts.push({ type: ctx.type, value: ctx.value });
+             } else {
+                 unsent.push(ctx.type);
+             }
          }
-         const unsent = Array.from(this.activeSabrContextTypes).filter(t => !this.sabrContexts.has(t));
 
          const preferredAudioFormatIds = audioFormat ? [this.resolveFormatIdForRequest(audioFormat)] : [];
          const preferredVideoFormatIds = videoFormat ? [this.resolveFormatIdForRequest(videoFormat)] : [];
@@ -623,12 +892,17 @@ export class SabrStream extends PassThrough {
          });
 
          const requestBody = VideoPlaybackAbrRequest.encode({
-            clientAbrState: abrState,
+            clientAbrState: {
+                ...abrState,
+                playerTimeMs: BigInt(abrState.playerTimeMs || 0).toString(),
+                bandwidthEstimate: BigInt(abrState.bandwidthEstimate || 0).toString(),
+                timeSinceLastActionMs: 0n
+            },
+            selectedFormatIds: selectedFormatIds,
+            bufferedRanges,
+            videoPlaybackUstreamerConfig: typeof this.videoPlaybackUstreamerConfig === 'string' ? base64ToU8(this.videoPlaybackUstreamerConfig) : this.videoPlaybackUstreamerConfig,
             preferredAudioFormatIds,
             preferredVideoFormatIds,
-            selectedFormatIds: selectedFormatIds,
-            videoPlaybackUstreamerConfig: typeof this.videoPlaybackUstreamerConfig === 'string' ? base64ToU8(this.videoPlaybackUstreamerConfig) : this.videoPlaybackUstreamerConfig,
-            bufferedRanges,
             streamerContext: {
                 poToken: this.poToken,
                 playbackCookie: this.nextRequestPolicy?.playbackCookie,
@@ -662,7 +936,7 @@ export class SabrStream extends PassThrough {
 
         const reqPreviewB64 = b64Trunc(requestBody, 1024);
         logger('debug', 'SABR', `Traffic -> rn=${trafficReq.rn} bodyB64[1024B]=${reqPreviewB64.length > 260 ? (reqPreviewB64.slice(0, 260) + '...') : reqPreviewB64} (full in sabr_traffic.jsonl)`);
-        
+
         const rn = this.requestNumber;
         const url = new URL(this.serverAbrStreamingUrl);
         url.searchParams.set('rn', rn.toString());
@@ -672,7 +946,7 @@ export class SabrStream extends PassThrough {
             'content-type': 'application/x-protobuf',
             'accept': 'application/vnd.yt-ump',
             'x-goog-visitor-id': this.visitorData || "",
-            'x-youtube-client-name': '1',
+            'x-youtube-client-name': String(this.clientInfo?.clientName || '1'),
             'x-youtube-client-version': this.clientInfo?.clientVersion || "",
             'origin': 'https://www.youtube.com',
             'referer': `https://www.youtube.com/watch?v=${this.videoId}`,
@@ -687,7 +961,8 @@ export class SabrStream extends PassThrough {
         const res = await fetch(url.toString(), {
             method: 'POST',
             headers,
-            body: requestBody
+            body: requestBody,
+            signal: this.abortController.signal
         });
 
         if (!res.ok) {
@@ -743,6 +1018,8 @@ export class SabrStream extends PassThrough {
 
         this.mediaHeadersProcessed = false;
 
+        let activePartial = null;
+
         while (true) {
             const { done, value } = await reader.read();
             if (done) break;
@@ -761,50 +1038,111 @@ export class SabrStream extends PassThrough {
             buffer.append(value);
 
             const ump = new UmpReader(buffer);
-            ump.read((part) => {
-                partCounts[part.type] = (partCounts[part.type] || 0) + 1;
-                partSeq.push({ type: part.type, name: umpPartName(part.type), size: part.size });
+            try {
+                const res = ump.read((part) => {
+                    if (this._aborted) return;
 
-                if (part.type === UMPPartId.MEDIA) saw.media = true;
-                else if (part.type === UMPPartId.MEDIA_HEADER) saw.mediaHeader = true;
-                else if (part.type === UMPPartId.MEDIA_END) saw.mediaEnd = true;
-                else if (part.type === UMPPartId.NEXT_REQUEST_POLICY) saw.nextRequestPolicy = true;
-                else if (part.type === UMPPartId.PLAYBACK_START_POLICY) saw.playbackStartPolicy = true;
-                else if (part.type === UMPPartId.REQUEST_IDENTIFIER) saw.requestIdentifier = true;
-                else if (part.type === UMPPartId.REQUEST_CANCELLATION_POLICY) saw.requestCancellationPolicy = true;
-                else if (part.type === UMPPartId.SABR_ERROR) saw.sabrError = true;
-                else if (part.type === UMPPartId.SABR_REDIRECT) saw.sabrRedirect = true;
-                else if (part.type === UMPPartId.SABR_CONTEXT_UPDATE) saw.sabrContextUpdate = true;
-                else if (part.type === UMPPartId.STREAM_PROTECTION_STATUS) saw.streamProtectionStatus = true;
+                    let handled = false;
+                    if (part.type === UMPPartId.MEDIA && activePartial && activePartial.type === UMPPartId.MEDIA) {
+                         const alreadyPushed = activePartial.processedBytes;
+                         const remainder = part.data.split(alreadyPushed).remainingBuffer;
 
-                if (this.enableTrafficDump && this.trafficDumpMaxBytes > 0) {
-                    const shouldDumpPayload = (part.type !== UMPPartId.MEDIA) && (part.type !== UMPPartId.MEDIA_HEADER) && (part.type !== UMPPartId.MEDIA_END);
-                    if (shouldDumpPayload && part.size <= this.trafficDumpMaxBytes) {
-                        try {
-                            const payload = concatenateChunks(part.data.chunks);
-                            let decoded;
+                         const headerId = activePartial.id ?? (part.data.getLength() > 0 ? part.data.getUint8(0) : 0);
+                         const isFirst = alreadyPushed === 0;
+
+                         this.handleMediaPartial(remainder, headerId, isFirst);
+                         handled = true;
+                         activePartial = null;
+                    }
+
+                    if (activePartial) activePartial = null;
+
+                    partCounts[part.type] = (partCounts[part.type] || 0) + 1;
+                    partSeq.push({ type: part.type, name: umpPartName(part.type), size: part.size });
+
+                    if (part.type === UMPPartId.MEDIA) saw.media = true;
+                    else if (part.type === UMPPartId.MEDIA_HEADER) saw.mediaHeader = true;
+                    else if (part.type === UMPPartId.MEDIA_END) saw.mediaEnd = true;
+                    else if (part.type === UMPPartId.NEXT_REQUEST_POLICY) saw.nextRequestPolicy = true;
+                    else if (part.type === UMPPartId.PLAYBACK_START_POLICY) saw.playbackStartPolicy = true;
+                    else if (part.type === UMPPartId.REQUEST_IDENTIFIER) saw.requestIdentifier = true;
+                    else if (part.type === UMPPartId.REQUEST_CANCELLATION_POLICY) saw.requestCancellationPolicy = true;
+                    else if (part.type === UMPPartId.SABR_ERROR) saw.sabrError = true;
+                    else if (part.type === UMPPartId.SABR_REDIRECT) saw.sabrRedirect = true;
+                    else if (part.type === UMPPartId.SABR_CONTEXT_UPDATE) saw.sabrContextUpdate = true;
+                    else if (part.type === UMPPartId.STREAM_PROTECTION_STATUS) saw.streamProtectionStatus = true;
+
+                    if (this.enableTrafficDump && this.trafficDumpMaxBytes > 0) {
+                        const shouldDumpPayload = (part.type !== UMPPartId.MEDIA) && (part.type !== UMPPartId.MEDIA_HEADER) && (part.type !== UMPPartId.MEDIA_END);
+                        if (shouldDumpPayload && part.size <= this.trafficDumpMaxBytes) {
                             try {
-                                if (part.type === UMPPartId.PLAYBACK_START_POLICY) decoded = PlaybackStartPolicy.decode(new ProtoReader(payload), payload.length);
-                                else if (part.type === UMPPartId.REQUEST_IDENTIFIER) decoded = RequestIdentifier.decode(new ProtoReader(payload), payload.length);
-                                else if (part.type === UMPPartId.REQUEST_CANCELLATION_POLICY) decoded = RequestCancellationPolicy.decode(new ProtoReader(payload), payload.length);
-                            } catch {}
+                                const payload = concatenateChunks(part.data.chunks);
+                                let decoded;
+                                try {
+                                    if (part.type === UMPPartId.PLAYBACK_START_POLICY) decoded = PlaybackStartPolicy.decode(new ProtoReader(payload), payload.length);
+                                    else if (part.type === UMPPartId.REQUEST_IDENTIFIER) decoded = RequestIdentifier.decode(new ProtoReader(payload), payload.length);
+                                    else if (part.type === UMPPartId.REQUEST_CANCELLATION_POLICY) decoded = RequestCancellationPolicy.decode(new ProtoReader(payload), payload.length);
+                                } catch {}
 
-                            partDumps.push({
-                                type: part.type,
-                                name: umpPartName(part.type),
-                                size: part.size,
-                                sha256: sha256Hex(payload),
-                                payloadB64: b64Trunc(payload, this.trafficDumpMaxBytes),
-                                payloadB64Truncated: payload.length > this.trafficDumpMaxBytes,
-                                decoded
-                            });
-                        } catch {}
+                                partDumps.push({
+                                    type: part.type,
+                                    name: umpPartName(part.type),
+                                    size: part.size,
+                                    sha256: sha256Hex(payload),
+                                    payloadB64: b64Trunc(payload, this.trafficDumpMaxBytes),
+                                    payloadB64Truncated: payload.length > this.trafficDumpMaxBytes,
+                                    decoded
+                                });
+                            } catch {}
+                        }
+                    }
+
+                    if (!handled) {
+                        const handler = this.umpPartHandlers.get(part.type);
+                        if (handler) handler(part);
+                    }
+                });
+
+                if (res && res.incomplete) {
+                    if (!activePartial) {
+                        activePartial = {
+                            type: res.type,
+                            totalSize: res.size,
+                            headerSize: res.headerSize,
+                            processedBytes: 0,
+                            id: undefined
+                        };
+                    }
+
+                    if (res.type === UMPPartId.MEDIA) {
+                        const available = res.data.getLength();
+                        const newBytesCount = available - activePartial.processedBytes;
+
+                        if (newBytesCount > 0) {
+                             const split = res.data.split(activePartial.processedBytes);
+                             const newChunk = split.remainingBuffer;
+
+                             let headerId = activePartial.id;
+
+                             if (activePartial.processedBytes === 0 && newChunk.getLength() >= 1) {
+                                 headerId = newChunk.getUint8(0);
+                                 activePartial.id = headerId;
+                             }
+
+                             if (headerId !== undefined) {
+                                 const isFirst = (activePartial.processedBytes === 0);
+                                 this.handleMediaPartial(newChunk, headerId, isFirst);
+                             }
+
+                             activePartial.processedBytes += newBytesCount;
+                        }
                     }
                 }
-
-                const handler = this.umpPartHandlers.get(part.type);
-                if (handler) handler(part);
-            });
+            } catch (err) {
+                if (this._aborted) return;
+                throw err;
+            }
+            buffer = ump.compositeBuffer;
             buffer = ump.compositeBuffer;
         }
 
@@ -845,6 +1183,16 @@ export class SabrStream extends PassThrough {
         if (saw.media) {
             this.mediaHeadersProcessed = true;
             this.cachedBufferedRanges = undefined;
+            this.noMediaStreak = 0;
+        } else if (trafficRes.policy.backoffTimeMs > 0) {
+            this.noMediaStreak++;
+            this.cachedBufferedRanges = undefined;
+
+            if (this.noMediaStreak >= 12) {
+                logger('warn', 'SABR', `Stall detected (noMediaStreak=${this.noMediaStreak}). Signaling for re-resolution.`);
+                this.emit('stall');
+                this.noMediaStreak = 0;
+            }
         }
     }
 }

--- a/src/sources/youtube/sabr.js
+++ b/src/sources/youtube/sabr.js
@@ -1143,7 +1143,6 @@ export class SabrStream extends PassThrough {
                 throw err;
             }
             buffer = ump.compositeBuffer;
-            buffer = ump.compositeBuffer;
         }
 
         const responseDump = this.enableTrafficDump && responseDumpChunks.length


### PR DESCRIPTION
## Changes

Refiz o potoken inteiro do zero:

O youtube quando detectava potokens invalidas (que estavam sendo geradas sem ser pelo botguard e DOM), retornatava o stream protection 2 (que bloqueia baixar acima de 60000 ms, independente da formação do request)
Agora pra implementação em si, foi totalmente baseada em exemplos https://github.com/LuanRT/BgUtils/blob/main/examples/node/innertube-challenge-fetcher-example.ts#L30, meio que fazendo 

Também, toda vez que for detectado um stream protection 2, a potoken vai ser re-generada (por algum motivo isso funcionou enquanto eu tava fazendo)

Diferença entre virtualPlayerTime é  playerTimeMs

virtualPlayerTime e oq ta tocando agora (vai representar o tempo exato onde o som estaria tocando se fosse um player real e não simulado)
playerTimeMs ele representa a ponta do buffer, não segue o tempo de reprodução, ele aparece a cada novo segmento (um chunk) é baixado completamente

No sabr.js: 

usei a matematica entre startMs com o segmentDuration pra calcular o tempo que vai terminar esse segmento, isso reduz o uso de RN, fica parecido com o youtube que manda bem pouco no website.
Usei valores simulados (como 15mb/s pra uma bandwith) pro youtube reconhecer como se fosse uma request valida, ainda da pra melhorar isso na real com o connection manager nosso provavelmente
Analisei a formação e comparei RNs (exemplo RN 2 - RN 3 ) pra ver oq mudava entre um e outro diretamente no binario, dai eu percebi que esta faltando isso na formação dos URLs (alr = yes, ump = 1, srfvp = 1)

Coisas que não tão sendo usadas por enquanto:

Sistema de recovery (eu fiz como o que a gente fez no live, re-usar o resolve() nele pra ver se dava certo, parcialmente funciona, mas sempre vai retornar o RN 0 querendo ou não, então o som so vai ficar em um loop de 0-60secs)
SABR no android (Funciona por 60 segundos, esse client não precisa de potoken pra funcionar, mas como o SABR precisa da webPotoken pra ser funcional então não deu certo).

Ump writer/reader: não ta sendo usado ainda incrivelmente, mas ja deixei meio que "pronto" se algum dia for preciso

## Why 


## Checkmarks

- [ X ] The modified endpoints have been tested.
- [ ] Used the same indentation as the rest of the project.
- [ X ] Still compatible with LavaLink clients.

## Additional information

Creditos geral (DOCS que li, onde peguei exemplos, API keys, etc):
https://github.com/gsuberland/UMP_Format/blob/main/UMP_Format.md
https://github.com/LuanRT/kira
https://github.com/LuanRT/BgUtils
https://github.com/LuanRT/googlevideo
https://github.com/shaka-project/shaka-player