### PR TITLE
improve: Add YouTube fallback for Audiomack, Gaana, and JioSaavn source 

### DIFF
--- a/src/sources/audiomack.js
+++ b/src/sources/audiomack.js
@@ -283,26 +283,15 @@ export default class AudioMackSource {
       })
 
       if (error || !body) {
-        return {
-          exception: {
-            message:
-              error?.message || 'Failed to get playback URL from Audiomack API',
-            severity: 'fault',
-            cause: 'StreamLink'
-          }
-        }
+        throw new Error(
+          error?.message || 'Failed to get playback URL from Audiomack API'
+        )
       }
 
       const json = parseJsonBody(body)
       const data = normalizeApiResult(json)
       if (!data) {
-        return {
-          exception: {
-            message: 'Invalid response from Audiomack API',
-            severity: 'fault',
-            cause: 'StreamLink'
-          }
-        }
+        throw new Error('Invalid response from Audiomack API')
       }
 
       const streamUrl =
@@ -313,26 +302,34 @@ export default class AudioMackSource {
         data.stream_url
 
       if (!streamUrl) {
-        return {
-          exception: {
-            message: 'Invalid or missing streaming URL in response',
-            severity: 'fault',
-            cause: 'StreamLink'
-          }
-        }
+        throw new Error('Invalid or missing streaming URL in response')
       }
 
       const format = guessFormatFromUrl(streamUrl)
       return { url: streamUrl, protocol: 'https', format }
     } catch (e) {
+      logger(
+        'warn',
+        'Audiomack',
+        `Direct stream failed for ${track.title}: ${e.message}. Falling back to YouTube.`
+      )
+    }
+
+    const searchResult = await this.nodelink.sources.searchWithDefault(
+      `${track.title} ${track.author}`
+    )
+
+    const bestMatch = getBestMatch(searchResult.data, track)
+    if (!bestMatch)
       return {
         exception: {
-          message: e.message || 'Failed to get playback URL from Audiomack API',
-          severity: 'fault',
-          cause: 'StreamLink'
+          message: 'No suitable alternative found.',
+          severity: 'fault'
         }
       }
-    }
+
+    const streamInfo = await this.nodelink.sources.getTrackUrl(bestMatch.info)
+    return { newTrack: bestMatch, ...streamInfo }
   }
 
   async loadStream(decodedTrack, url, _protocol, additionalData) {

--- a/src/sources/audiomack.js
+++ b/src/sources/audiomack.js
@@ -283,15 +283,26 @@ export default class AudioMackSource {
       })
 
       if (error || !body) {
-        throw new Error(
-          error?.message || 'Failed to get playback URL from Audiomack API'
-        )
-      }
+        return {
+          exception: {
+            message: error?.message || 'Failed to get playback URL from Audiomack API',
+            severity: 'fault',
+            cause: 'StreamLink'
+          }
+       };
+     }
+
 
       const json = parseJsonBody(body)
       const data = normalizeApiResult(json)
       if (!data) {
-        throw new Error('Invalid response from Audiomack API')
+        return {
+          exception: {
+            message: 'Invalid response from Audiomack API',
+            severity: 'fault',
+            cause: 'StreamLink'
+          }
+        };   
       }
 
       const streamUrl =
@@ -302,7 +313,13 @@ export default class AudioMackSource {
         data.stream_url
 
       if (!streamUrl) {
-        throw new Error('Invalid or missing streaming URL in response')
+        return {
+          exception: {
+            message: 'Invalid or missing streaming URL in response',
+            severity: 'fault',
+            cause: 'StreamLink'
+          }
+        };
       }
 
       const format = guessFormatFromUrl(streamUrl)

--- a/src/sources/audiomack.js
+++ b/src/sources/audiomack.js
@@ -1,4 +1,4 @@
-import { http1makeRequest, logger, encodeTrack } from '../utils.js'
+import { http1makeRequest, logger, encodeTrack , getBestMatch} from '../utils.js'
 import crypto from 'node:crypto'
 import { PassThrough } from 'node:stream'
 

--- a/src/sources/gaana.js
+++ b/src/sources/gaana.js
@@ -2,7 +2,7 @@
 * Credits: https://github.com/southctrl; adapted for NodeLink
 */
 
-import { encodeTrack, http1makeRequest, logger } from '../utils.js'
+import { encodeTrack, http1makeRequest, logger, getBestMatch } from '../utils.js'
 import HLSHandler from '../playback/hls/HLSHandler.js'
 
 const USER_AGENT =
@@ -101,7 +101,7 @@ export default class GaanaSource {
       if (!/^\d+$/.test(String(trackId))) {
         const trackData = await this.getJson(`/api/songs/${encodeURIComponent(trackId)}`)
         if (!trackData?.track_id) {
-          return { exception: { message: 'Track metadata not found for stream.', severity: 'common' } }
+          throw new Error('Track metadata not found for stream.')
         }
         trackId = trackData.track_id
       }
@@ -111,13 +111,13 @@ export default class GaanaSource {
       )
 
       if (!streamData) {
-        return { exception: { message: 'Stream URL not found.', severity: 'common' } }
+        throw new Error('Stream URL not found.')
       }
 
       const hlsUrl = streamData.hlsUrl || streamData.hls_url || null
       const url = hlsUrl || streamData.url
       if (!url) {
-        return { exception: { message: 'No playable stream URL.', severity: 'common' } }
+        throw new Error('No playable stream URL.')
       }
 
       const segments = Array.isArray(streamData.segments)
@@ -137,9 +137,28 @@ export default class GaanaSource {
             }
       }
     } catch (e) {
-      logger('error', 'Gaana', `Stream resolve error: ${e.message}`)
-      return { exception: { message: e.message, severity: 'fault' } }
+      logger(
+        'warn',
+        'Gaana',
+        `Direct stream failed for ${decodedTrack.title}: ${e.message}. Falling back to YouTube.`
+      )
     }
+
+    const searchResult = await this.nodelink.sources.searchWithDefault(
+      `${decodedTrack.title} ${decodedTrack.author}`
+    )
+
+    const bestMatch = getBestMatch(searchResult.data, decodedTrack)
+    if (!bestMatch)
+      return {
+        exception: {
+          message: 'No suitable alternative found.',
+          severity: 'fault'
+        }
+      }
+
+    const streamInfo = await this.nodelink.sources.getTrackUrl(bestMatch.info)
+    return { newTrack: bestMatch, ...streamInfo }
   }
 
   async loadStream(track, url, protocol, additionalData) {

--- a/src/sources/gaana.js
+++ b/src/sources/gaana.js
@@ -101,7 +101,7 @@ export default class GaanaSource {
       if (!/^\d+$/.test(String(trackId))) {
         const trackData = await this.getJson(`/api/songs/${encodeURIComponent(trackId)}`)
         if (!trackData?.track_id) {
-          throw new Error('Track metadata not found for stream.')
+          return { exception: { message: 'Track metadata not found for stream.', severity: 'common' } }
         }
         trackId = trackData.track_id
       }
@@ -111,13 +111,13 @@ export default class GaanaSource {
       )
 
       if (!streamData) {
-        throw new Error('Stream URL not found.')
+        return { exception: { message: 'Stream URL not found.', severity: 'common' } }
       }
 
       const hlsUrl = streamData.hlsUrl || streamData.hls_url || null
       const url = hlsUrl || streamData.url
       if (!url) {
-        throw new Error('No playable stream URL.')
+        return { exception: { message: 'No playable stream URL.', severity: 'common' } }
       }
 
       const segments = Array.isArray(streamData.segments)

--- a/src/sources/jiosaavn.js
+++ b/src/sources/jiosaavn.js
@@ -1,5 +1,5 @@
 import { PassThrough } from 'node:stream'
-import { encodeTrack, http1makeRequest, logger } from '../utils.js'
+import { encodeTrack, http1makeRequest, logger, getBestMatch, } from '../utils.js'
 import { desEcbDecryptBase64ToUtf8 } from '../decrypters/des-ecb.js'
 
 const API_BASE = 'https://www.jiosaavn.com/api.php'
@@ -170,14 +170,7 @@ export default class JioSaavnSource {
     }
   }
 
-  async getTrackUrl(decodedTrack, itag, forceRefresh = false) {
-    if (!forceRefresh) {
-      const cached = this.nodelink.trackCacheManager.get('jiosaavn', decodedTrack.identifier)
-      if (cached) return cached
-    }
-
-    const trackId = decodedTrack.identifier
-
+  async getTrackUrl(decodedTrack) {
     try {
       logger(
         'debug',
@@ -188,18 +181,11 @@ export default class JioSaavnSource {
       const trackData = await this._fetchSongMetadata(decodedTrack.identifier)
 
       if (!trackData) {
-        return {
-          exception: { message: 'Track metadata not found', severity: 'common' }
-        }
+        throw new Error('Track metadata not found')
       }
 
       if (!trackData.encrypted_media_url) {
-        return {
-          exception: {
-            message: 'No encrypted_media_url found',
-            severity: 'fault'
-          }
-        }
+        throw new Error('No encrypted_media_url found')
       }
 
       let playbackUrl = this._decryptUrl(trackData.encrypted_media_url)
@@ -215,9 +201,28 @@ export default class JioSaavnSource {
         additionalData: {}
       }
     } catch (e) {
-      logger('error', 'JioSaavn', `Stream load error: ${e.message}`)
-      return { exception: { message: e.message, severity: 'fault' } }
+      logger(
+        'warn',
+        'JioSaavn',
+        `Direct stream failed for ${decodedTrack.title}: ${e.message}. Falling back to YouTube.`
+      )
     }
+
+    const searchResult = await this.nodelink.sources.searchWithDefault(
+      `${decodedTrack.title} ${decodedTrack.author}`
+    )
+
+    const bestMatch = getBestMatch(searchResult.data, decodedTrack)
+    if (!bestMatch)
+      return {
+        exception: {
+          message: 'No suitable alternative found.',
+          severity: 'fault'
+        }
+      }
+
+    const streamInfo = await this.nodelink.sources.getTrackUrl(bestMatch.info)
+    return { newTrack: bestMatch, ...streamInfo }
   }
 
   async loadStream(_track, url, _protocol, _additionalData) {

--- a/src/sources/jiosaavn.js
+++ b/src/sources/jiosaavn.js
@@ -181,11 +181,18 @@ export default class JioSaavnSource {
       const trackData = await this._fetchSongMetadata(decodedTrack.identifier)
 
       if (!trackData) {
-        throw new Error('Track metadata not found')
+        return {
+          exception: { message: 'Track metadata not found', severity: 'common' }
+        }
       }
 
       if (!trackData.encrypted_media_url) {
-        throw new Error('No encrypted_media_url found')
+        return {
+          exception: {
+            message: 'No encrypted_media_url found',
+            severity: 'fault'
+          }
+        }
       }
 
       let playbackUrl = this._decryptUrl(trackData.encrypted_media_url)


### PR DESCRIPTION
## Changes

Added youtube fallback for audiomack, faana, and jiosaavn sources when direct streaming fails.(Similar to deezer one) . 
Also removed the track cache calls in jiosaavn source manager since it was never being set.

## Why 
Some songs on these sources were failing to extract the playback URLs through api, resulting in playback failures. 

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information
For eg: https://audiomack.com/nayel/song/roop

I was not able to reproduce this for jiosaavn and gaana but some users of my bot reported it.
