### PR TITLE
improve: replace myzod with fastest-validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "@performanc/voice": "github:PerformanC/voice",
     "@toddynnn/symphonia-decoder": "1.0.6",
     "@toddynnn/voice-opus": "^1.0.1",
+    "fastest-validator": "^1.19.1",
     "jsdom": "^27.4.0",
-    "mp4box": "^2.3.0",
-    "myzod": "^1.12.1"
+    "mp4box": "^2.3.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.10",

--- a/src/api/decodeTrack.js
+++ b/src/api/decodeTrack.js
@@ -1,17 +1,29 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { decodeTrack, logger, sendErrorResponse } from '../utils.js'
 
-const decodeTrackSchema = myzod.object({
-  encodedTrack: myzod.string()
+const v = new Validator({ haltOnFirstError: true })
+
+const checkDecodeTrack = v.compile({
+  encodedTrack: {
+    type: 'string',
+    empty: false,
+    messages: {
+      required: 'Missing encodedTrack parameter.',
+      string: 'Missing encodedTrack parameter.',
+      stringEmpty: 'Missing encodedTrack parameter.'
+    }
+  }
 })
 
 function handler(_nodelink, req, res, sendResponse, parsedUrl) {
-  const result = decodeTrackSchema.try({
-    encodedTrack: parsedUrl.searchParams.get('encodedTrack')
-  })
+  const data = {
+    encodedTrack: parsedUrl.searchParams.get('encodedTrack') ?? undefined
+  }
 
-  if (result instanceof myzod.ValidationError) {
-    const errorMessage = result.message || 'Missing encodedTrack parameter.'
+  const validation = checkDecodeTrack(data)
+
+  if (validation !== true) {
+    const errorMessage = validation?.[0]?.message || 'Missing encodedTrack parameter.'
     sendErrorResponse(
       req,
       res,
@@ -24,19 +36,20 @@ function handler(_nodelink, req, res, sendResponse, parsedUrl) {
     return
   }
 
-  const encodedTrack = result.encodedTrack.replace(/ /g, '+')
+  const encodedTrack = data.encodedTrack.replace(/ /g, '+')
 
   try {
     logger('debug', 'Tracks', `Decoding track: ${encodedTrack}`)
     const decodedTrack = decodeTrack(encodedTrack)
+
     if (decodedTrack.details) {
       decodedTrack.pluginInfo = {
         ...decodedTrack.pluginInfo,
         details: decodedTrack.details
       }
-
       delete decodedTrack.details
     }
+
     sendResponse(req, res, decodedTrack, 200)
   } catch (err) {
     logger('error', 'Tracks', `Failed to decode track ${encodedTrack}:`, err)
@@ -51,6 +64,7 @@ function handler(_nodelink, req, res, sendResponse, parsedUrl) {
     )
   }
 }
+
 export default {
   handler
 }

--- a/src/api/decodeTracks.js
+++ b/src/api/decodeTracks.js
@@ -1,15 +1,24 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { decodeTrack, logger, sendErrorResponse } from '../utils.js'
 
-const decodeTracksSchema = myzod.array(myzod.string()).min(1)
+const v = new Validator({ haltOnFirstError: true })
+
+const decodeTracksSchema = v.compile({
+  $$root: true,
+  type: 'array',
+  items: 'string',
+  min: 1,
+  messages: {
+    arrayMin: 'encodedTracks parameter must be a non-empty array of strings.',
+    array: 'encodedTracks parameter must be a non-empty array of strings.'
+  }
+})
 
 function handler(_nodelink, req, res, sendResponse, parsedUrl) {
-  const result = decodeTracksSchema.try(req.body)
+  const validation = decodeTracksSchema(req.body)
 
-  if (result instanceof myzod.ValidationError) {
-    const errorMessage =
-      result.message ||
-      'encodedTracks parameter must be a non-empty array of strings.'
+  if (validation !== true) {
+    const errorMessage = validation?.[0]?.message || 'encodedTracks parameter must be a non-empty array of strings.'
     sendErrorResponse(
       req,
       res,
@@ -22,7 +31,7 @@ function handler(_nodelink, req, res, sendResponse, parsedUrl) {
     return
   }
 
-  const encodedTracks = result
+  const encodedTracks = req.body
 
   const decodedTracks = []
   logger('debug', 'Tracks', `Decoding ${encodedTracks.length} tracks.`)

--- a/src/api/encodeTrack.js
+++ b/src/api/encodeTrack.js
@@ -1,17 +1,21 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { encodeTrack, logger, sendErrorResponse } from '../utils.js'
 
-const encodeTrackSchema = myzod.object({
-  track: myzod.string()
+const v = new Validator({ haltOnFirstError: true })
+
+const encodeTrackSchema = v.compile({
+  track: { type: 'string', empty: false, messages: { required: 'Missing track parameter.', stringEmpty: 'Missing track parameter.' } }
 })
 
 function handler(_nodelink, req, res, sendResponse, parsedUrl) {
-  const result = encodeTrackSchema.try({
-    track: parsedUrl.searchParams.get('track')
-  })
+  const data = {
+    track: parsedUrl.searchParams.get('track') ?? undefined
+  }
 
-  if (result instanceof myzod.ValidationError) {
-    const errorMessage = result.message || 'Missing track parameter.'
+  const validation = encodeTrackSchema(data)
+
+  if (validation !== true) {
+    const errorMessage = validation?.[0]?.message || 'Missing track parameter.'
     sendErrorResponse(
       req,
       res,
@@ -24,7 +28,7 @@ function handler(_nodelink, req, res, sendResponse, parsedUrl) {
     return
   }
 
-  const track = result.track
+  const track = data.track
 
   try {
     logger('debug', 'Tracks', `Encoding track: ${track}`)

--- a/src/api/encodedTracks.js
+++ b/src/api/encodedTracks.js
@@ -1,23 +1,31 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { encodeTrack, logger, sendErrorResponse } from '../utils.js'
 
-const encodedTracksSchema = myzod
-  .array(
-    myzod
-      .object({
-        encoded: myzod.string(),
-        info: myzod.object({}).allowUnknownKeys()
-      })
-      .allowUnknownKeys()
-  )
-  .min(1)
+const v = new Validator({ haltOnFirstError: true })
+
+const encodedTracksSchema = v.compile({
+  $$root: true,
+  type: 'array',
+  min: 1,
+  items: {
+    type: 'object',
+    props: {
+      encoded: { type: 'string', empty: false },
+      info: { type: 'object', optional: false }
+    },
+    $$strict: false
+  },
+  messages: {
+    arrayMin: 'tracks parameter must be an array and cannot be empty.'
+  }
+})
 
 function handler(_nodelink, req, res, sendResponse, parsedUrl) {
-  const result = encodedTracksSchema.try(req.body)
+  const validation = encodedTracksSchema(req.body)
 
-  if (result instanceof myzod.ValidationError) {
+  if (validation !== true) {
     const errorMessage =
-      result.message || 'tracks parameter must be an array and cannot be empty.'
+      validation?.[0]?.message || 'tracks parameter must be an array and cannot be empty.'
     sendErrorResponse(
       req,
       res,
@@ -30,7 +38,7 @@ function handler(_nodelink, req, res, sendResponse, parsedUrl) {
     return
   }
 
-  const tracks = result
+  const tracks = req.body
 
   const encodedTracks = []
   logger('debug', 'Tracks', `Encoding ${tracks.length} tracks.`)

--- a/src/api/loadChapters.js
+++ b/src/api/loadChapters.js
@@ -1,17 +1,29 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { decodeTrack, logger, sendErrorResponse } from '../utils.js'
 
-const loadChaptersSchema = myzod.object({
-  encodedTrack: myzod.string()
+const v = new Validator({ haltOnFirstError: true })
+
+const loadChaptersSchema = v.compile({
+  encodedTrack: {
+    type: 'string',
+    empty: false,
+    messages: {
+      required: 'Missing encodedTrack parameter.',
+      string: 'Missing encodedTrack parameter.',
+      stringEmpty: 'Missing encodedTrack parameter.'
+    }
+  }
 })
 
 async function handler(nodelink, req, res, sendResponse, parsedUrl) {
-  const result = loadChaptersSchema.try({
-    encodedTrack: parsedUrl.searchParams.get('encodedTrack')
-  })
+  const data = {
+    encodedTrack: parsedUrl.searchParams.get('encodedTrack') ?? undefined
+  }
 
-  if (result instanceof myzod.ValidationError) {
-    const errorMessage = result.message || 'Missing encodedTrack parameter.'
+  const validation = loadChaptersSchema(data)
+
+  if (validation !== true) {
+    const errorMessage = validation?.[0]?.message || 'Missing encodedTrack parameter.'
     return sendErrorResponse(
       req,
       res,
@@ -22,7 +34,7 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
     )
   }
 
-  const encodedTrack = result.encodedTrack.replace(/ /g, '+')
+  const encodedTrack = data.encodedTrack.replace(/ /g, '+')
 
   try {
     const decodedTrack = decodeTrack(encodedTrack)

--- a/src/api/loadLyrics.js
+++ b/src/api/loadLyrics.js
@@ -1,19 +1,23 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { decodeTrack, logger, sendErrorResponse } from '../utils.js'
 
-const loadLyricsSchema = myzod.object({
-  encodedTrack: myzod.string(),
-  lang: myzod.string().optional()
+const v = new Validator({ haltOnFirstError: true })
+
+const loadLyricsSchema = v.compile({
+  encodedTrack: { type: 'string', empty: false, messages: { required: 'Missing encodedTrack parameter.', stringEmpty: 'Missing encodedTrack parameter.' } },
+  lang: { type: 'string', optional: true }
 })
 
 async function handler(nodelink, req, res, sendResponse, parsedUrl) {
-  const result = loadLyricsSchema.try({
-    encodedTrack: parsedUrl.searchParams.get('encodedTrack'),
+  const data = {
+    encodedTrack: parsedUrl.searchParams.get('encodedTrack') ?? undefined,
     lang: parsedUrl.searchParams.get('lang') || undefined
-  })
+  }
 
-  if (result instanceof myzod.ValidationError) {
-    const errorMessage = result.message || 'Missing encodedTrack parameter.'
+  const validation = loadLyricsSchema(data)
+
+  if (validation !== true) {
+    const errorMessage = validation?.[0]?.message || 'Missing encodedTrack parameter.'
     logger('warn', 'Lyrics', errorMessage)
     return sendErrorResponse(
       req,
@@ -25,8 +29,8 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
     )
   }
 
-  const encodedTrack = result.encodedTrack.replace(/ /g, '+')
-  const language = result.lang
+  const encodedTrack = data.encodedTrack.replace(/ /g, '+')
+  const language = data.lang
 
   try {
     const decodedTrack = decodeTrack(encodedTrack)

--- a/src/api/loadStream.js
+++ b/src/api/loadStream.js
@@ -1,13 +1,15 @@
 import { pipeline } from 'node:stream'
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { createPCMStream } from '../playback/processing/streamProcessor.js'
 import { decodeTrack, logger, sendErrorResponse } from '../utils.js'
 
-const loadStreamSchema = myzod.object({
-  encodedTrack: myzod.string(),
-  volume: myzod.number().min(0).max(1000).optional(),
-  position: myzod.number().min(0).optional(),
-  filters: myzod.unknown().optional()
+const v = new Validator({ haltOnFirstError: true })
+
+const loadStreamSchema = v.compile({
+  encodedTrack: { type: 'string', empty: false },
+  volume: { type: 'number', min: 0, max: 1000, optional: true },
+  position: { type: 'number', min: 0, optional: true },
+  filters: { type: 'any', optional: true }
 })
 
 async function handler(nodelink, req, res, _sendResponse, parsedUrl) {
@@ -22,10 +24,10 @@ async function handler(nodelink, req, res, _sendResponse, parsedUrl) {
     )
   }
 
-  let result
+  let data
   try {
     if (req.method === 'POST') {
-      result = loadStreamSchema.try(req.body)
+      data = req.body
     } else {
       const filtersRaw = parsedUrl.searchParams.get('filters')
       let filters
@@ -37,8 +39,8 @@ async function handler(nodelink, req, res, _sendResponse, parsedUrl) {
         }
       }
 
-      result = loadStreamSchema.try({
-        encodedTrack: parsedUrl.searchParams.get('encodedTrack'),
+      data = {
+        encodedTrack: parsedUrl.searchParams.get('encodedTrack') ?? undefined,
         volume: parsedUrl.searchParams.get('volume')
           ? Number(parsedUrl.searchParams.get('volume'))
           : undefined,
@@ -51,21 +53,23 @@ async function handler(nodelink, req, res, _sendResponse, parsedUrl) {
               )
             : undefined,
         filters
-      })
+      }
     }
 
-    if (result instanceof myzod.ValidationError) {
+    const validation = loadStreamSchema(data)
+
+    if (validation !== true) {
       return sendErrorResponse(
         req,
         res,
         400,
         'Bad Request',
-        result.message,
+        validation?.[0]?.message || 'Invalid parameters',
         parsedUrl.pathname
       )
     }
 
-    const { encodedTrack, volume = 100, position = 0, filters = {} } = result
+    const { encodedTrack, volume = 100, position = 0, filters = {} } = data
     const decodedTrack = decodeTrack(encodedTrack.replace(/ /g, '+'))
 
     if (!decodedTrack) {

--- a/src/api/loadTracks.js
+++ b/src/api/loadTracks.js
@@ -1,17 +1,29 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { logger, sendErrorResponse } from '../utils.js'
 
-const loadTracksSchema = myzod.object({
-  identifier: myzod.string()
+const v = new Validator({ haltOnFirstError: true })
+
+const loadTracksSchema = v.compile({
+  identifier: {
+    type: 'string',
+    empty: false,
+    messages: {
+      required: 'identifier parameter is required.',
+      string: 'identifier parameter is required.',
+      stringEmpty: 'identifier parameter is required.'
+    }
+  }
 })
 
 async function handler(nodelink, req, res, sendResponse, parsedUrl) {
-  const result = loadTracksSchema.try({
-    identifier: parsedUrl.searchParams.get('identifier')
-  })
+  const data = {
+    identifier: parsedUrl.searchParams.get('identifier') ?? undefined
+  }
 
-  if (result instanceof myzod.ValidationError) {
-    const errorMessage = result.message || 'identifier parameter is required.'
+  const validation = loadTracksSchema(data)
+
+  if (validation !== true) {
+    const errorMessage = validation?.[0]?.message || 'identifier parameter is required.'
     logger('warn', 'Tracks', errorMessage)
     return sendErrorResponse(
       req,
@@ -24,7 +36,7 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
     )
   }
 
-  const identifier = result.identifier.trim()
+  const identifier = data.identifier.trim()
   logger('debug', 'Tracks', `Loading tracks with identifier: "${identifier}"`)
 
   let url, source, query

--- a/src/api/meaning.js
+++ b/src/api/meaning.js
@@ -1,19 +1,31 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { decodeTrack, logger, sendErrorResponse } from '../utils.js'
 
-const meaningSchema = myzod.object({
-  encodedTrack: myzod.string(),
-  lang: myzod.string().optional()
+const v = new Validator({ haltOnFirstError: true })
+
+const meaningSchema = v.compile({
+  encodedTrack: {
+    type: 'string',
+    empty: false,
+    messages: {
+      required: 'encodedTrack parameter is required.',
+      string: 'encodedTrack parameter is required.',
+      stringEmpty: 'encodedTrack parameter is required.'
+    }
+  },
+  lang: { type: 'string', optional: true, default: 'en' }
 })
 
 async function handler(nodelink, req, res, sendResponse, parsedUrl) {
-  const result = meaningSchema.try({
-    encodedTrack: parsedUrl.searchParams.get('encodedTrack'),
-    lang: parsedUrl.searchParams.get('lang') || 'en'
-  })
+  const data = {
+    encodedTrack: parsedUrl.searchParams.get('encodedTrack') ?? undefined,
+    lang: parsedUrl.searchParams.get('lang') || undefined
+  }
 
-  if (result instanceof myzod.ValidationError) {
-    const errorMessage = result.message || 'encodedTrack parameter is required.'
+  const validation = meaningSchema(data)
+
+  if (validation !== true) {
+    const errorMessage = validation?.[0]?.message || 'encodedTrack parameter is required.'
     logger('warn', 'Meaning', errorMessage)
     return sendErrorResponse(
       req,
@@ -27,7 +39,7 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
   }
 
   let decodedTrack
-  const targetLang = result.lang
+  const targetLang = data.lang
   try {
     decodedTrack = decodeTrack(result.encodedTrack.replace(/ /g, '+'))
   } catch (err) {

--- a/src/api/routeplanner.js
+++ b/src/api/routeplanner.js
@@ -1,5 +1,7 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { sendErrorResponse, sendResponse } from '../utils.js'
+
+const v = new Validator({ haltOnFirstError: true })
 
 function getStatus(nodelink, req, res) {
   const routePlanner = nodelink.routePlanner
@@ -38,15 +40,15 @@ function getStatus(nodelink, req, res) {
   sendResponse(req, res, status, 200)
 }
 
-const freeAddressSchema = myzod.object({
-  address: myzod.string()
+const freeAddressSchema = v.compile({
+  address: { type: 'string', empty: false }
 })
 
 function freeAddress(nodelink, req, res) {
-  const result = freeAddressSchema.try(req.body)
+  const validation = freeAddressSchema(req.body)
 
-  if (result instanceof myzod.ValidationError) {
-    const errorMessage = result.message || 'The address field is required.'
+  if (validation !== true) {
+    const errorMessage = validation?.[0]?.message || 'The address field is required.'
     return sendErrorResponse(
       req,
       res,
@@ -57,7 +59,7 @@ function freeAddress(nodelink, req, res) {
     )
   }
 
-  const { address } = result
+  const { address } = req.body
 
   nodelink.routePlanner.freeIP(address)
   res.writeHead(204)

--- a/src/api/sessions.id.js
+++ b/src/api/sessions.id.js
@@ -1,12 +1,13 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { logger, sendErrorResponse } from '../utils.js'
 
-const sessionPatchSchema = myzod
-  .object({
-    resuming: myzod.boolean().optional(),
-    timeout: myzod.number().min(0).optional()
-  })
-  .allowUnknownKeys()
+const v = new Validator({ haltOnFirstError: true })
+
+const sessionPatchSchema = v.compile({
+  resuming: { type: 'boolean', optional: true },
+  timeout: { type: 'number', min: 0, optional: true },
+  $$strict: false
+})
 
 async function handler(nodelink, req, res, sendResponse, parsedUrl) {
   const parts = parsedUrl.pathname.split('/')
@@ -27,10 +28,10 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
     parsedUrl.pathname === `/v4/sessions/${sessionId}` &&
     req.method === 'PATCH'
   ) {
-    const result = sessionPatchSchema.try(req.body)
+    const validation = sessionPatchSchema(req.body)
 
-    if (result instanceof myzod.ValidationError) {
-      const errorMessage = result.message || 'Invalid PATCH payload'
+    if (validation !== true) {
+      const errorMessage = validation?.[0]?.message || 'Invalid PATCH payload'
       logger(
         'warn',
         'Session',
@@ -46,7 +47,7 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
       )
     }
 
-    const payload = result
+    const payload = req.body
     logger(
       'debug',
       'Session',

--- a/src/api/sessions.id.players.id.lyrics.subscribe.js
+++ b/src/api/sessions.id.players.id.lyrics.subscribe.js
@@ -1,18 +1,15 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { logger, sendErrorResponse } from '../utils.js'
 
-const querySchema = myzod.object({
-  skipTrackSource: myzod.string().optional()
+const v = new Validator({ haltOnFirstError: true })
+
+const querySchema = v.compile({
+  skipTrackSource: { type: 'string', optional: true }
 })
 
-const pathSchema = myzod.object({
-  sessionId: myzod.string(),
-  guildId: myzod
-    .string()
-    .withPredicate(
-      (val) => /^\d{17,20}$/.test(val),
-      'guildId must be 17-20 digits'
-    )
+const pathSchema = v.compile({
+  sessionId: { type: 'string', empty: false },
+  guildId: { type: 'string', pattern: /^\d{17,20}$/, messages: { stringPattern: 'guildId must be 17-20 digits' } }
 })
 
 async function handler(nodelink, req, res, _sendResponse, parsedUrl) {
@@ -21,13 +18,9 @@ async function handler(nodelink, req, res, _sendResponse, parsedUrl) {
   const sessionId = pathParts[3]
   const guildId = pathParts[5]
 
-  try {
-    pathSchema.parse({ sessionId, guildId })
-  } catch (error) {
-    if (error instanceof myzod.ValidationError) {
-      return sendErrorResponse(req, res, 400, error.message)
-    }
-    return sendErrorResponse(req, res, 400, 'Invalid path parameters')
+  const validation = pathSchema({ sessionId, guildId })
+  if (validation !== true) {
+    return sendErrorResponse(req, res, 400, validation?.[0]?.message || 'Invalid path parameters')
   }
 
   const session = nodelink.sessions.get(sessionId)
@@ -40,15 +33,16 @@ async function handler(nodelink, req, res, _sendResponse, parsedUrl) {
   }
 
   if (method === 'POST') {
-    const result = querySchema.try({
-        skipTrackSource: parsedUrl.searchParams.get('skipTrackSource')
-    })
+    const queryData = {
+      skipTrackSource: parsedUrl.searchParams.get('skipTrackSource') ?? undefined
+    }
+    const queryValidation = querySchema(queryData)
 
-    if (result instanceof myzod.ValidationError) {
-        return sendErrorResponse(req, res, 400, result.message)
+    if (queryValidation !== true) {
+      return sendErrorResponse(req, res, 400, queryValidation?.[0]?.message || 'Invalid parameters')
     }
 
-    const skipTrackSource = result.skipTrackSource === 'true'
+    const skipTrackSource = queryData.skipTrackSource === 'true'
 
     try {
         await session.players.subscribeLyrics(guildId, skipTrackSource)

--- a/src/api/sessions.id.players.id.mix.id.js
+++ b/src/api/sessions.id.players.id.mix.id.js
@@ -1,21 +1,17 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { logger, sendErrorResponse } from '../utils.js'
 
-const updateMixSchema = myzod
-  .object({
-    volume: myzod.number().min(0).max(1)
-  })
-  .allowUnknownKeys()
+const v = new Validator({ haltOnFirstError: true })
 
-const pathSchema = myzod.object({
-  sessionId: myzod.string(),
-  guildId: myzod
-    .string()
-    .withPredicate(
-      (val) => /^\d{17,20}$/.test(val),
-      'guildId must be 17-20 digits'
-    ),
-  mixId: myzod.string()
+const updateMixSchema = v.compile({
+  volume: { type: 'number', min: 0, max: 1, optional: false },
+  $$strict: false
+})
+
+const pathSchema = v.compile({
+  sessionId: { type: 'string', empty: false },
+  guildId: { type: 'string', pattern: /^\d{17,20}$/, messages: { stringPattern: 'guildId must be 17-20 digits' } },
+  mixId: { type: 'string', empty: false }
 })
 
 async function handler(nodelink, req, res, _sendResponse, parsedUrl) {
@@ -25,13 +21,9 @@ async function handler(nodelink, req, res, _sendResponse, parsedUrl) {
   const guildId = pathParts[5]
   const mixId = pathParts[7]
 
-  try {
-    pathSchema.parse({ sessionId, guildId, mixId })
-  } catch (error) {
-    if (error instanceof myzod.ValidationError) {
-      return sendErrorResponse(req, res, 400, error.message)
-    }
-    return sendErrorResponse(req, res, 400, 'Invalid path parameters')
+  const validation = pathSchema({ sessionId, guildId, mixId })
+  if (validation !== true) {
+    return sendErrorResponse(req, res, 400, validation?.[0]?.message || 'Invalid path parameters')
   }
 
   if (method === 'PATCH') {
@@ -56,7 +48,10 @@ async function handleUpdateMix(req, res, sessionId, guildId, mixId, nodelink) {
       }
     }
 
-    updateMixSchema.parse(body)
+    const bodyValidation = updateMixSchema(body)
+    if (bodyValidation !== true) {
+      return sendErrorResponse(req, res, 400, bodyValidation?.[0]?.message || 'Invalid parameters')
+    }
 
     const session = nodelink.sessions.get(sessionId)
     if (!session) {
@@ -82,9 +77,6 @@ async function handleUpdateMix(req, res, sessionId, guildId, mixId, nodelink) {
     res.writeHead(204)
     res.end()
   } catch (error) {
-    if (error instanceof myzod.ValidationError) {
-      return sendErrorResponse(req, res, 400, error.message)
-    }
     logger('error', 'MixAPI', `Error updating mix: ${error.message}`)
     return sendErrorResponse(req, res, 500, error.message)
   }

--- a/src/api/sessions.id.players.id.mix.js
+++ b/src/api/sessions.id.players.id.mix.js
@@ -1,29 +1,27 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { decodeTrack, logger, sendErrorResponse } from '../utils.js'
 
-const mixTrackSchema = myzod
-  .object({
-    encoded: myzod.string().nullable().optional(),
-    identifier: myzod.string().optional(),
-    userData: myzod.unknown().optional()
-  })
-  .allowUnknownKeys()
+const v = new Validator({ haltOnFirstError: true })
 
-const createMixSchema = myzod
-  .object({
-    track: mixTrackSchema,
-    volume: myzod.number().min(0).max(1).optional()
-  })
-  .allowUnknownKeys()
+const mixTrackSchema = {
+  type: 'object',
+  props: {
+    encoded: { type: 'string', nullable: true, optional: true },
+    identifier: { type: 'string', optional: true },
+    userData: { type: 'any', optional: true }
+  },
+  $$strict: false
+}
 
-const pathSchema = myzod.object({
-  sessionId: myzod.string(),
-  guildId: myzod
-    .string()
-    .withPredicate(
-      (val) => /^\d{17,20}$/.test(val),
-      'guildId must be 17-20 digits'
-    )
+const createMixSchema = v.compile({
+  track: mixTrackSchema,
+  volume: { type: 'number', min: 0, max: 1, optional: true },
+  $$strict: false
+})
+
+const pathSchema = v.compile({
+  sessionId: { type: 'string', empty: false },
+  guildId: { type: 'string', pattern: /^\d{17,20}$/, messages: { stringPattern: 'guildId must be 17-20 digits' } }
 })
 
 async function handler(nodelink, req, res, sendResponse, parsedUrl) {
@@ -32,13 +30,9 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
   const sessionId = pathParts[3]
   const guildId = pathParts[5]
 
-  try {
-    pathSchema.parse({ sessionId, guildId })
-  } catch (error) {
-    if (error instanceof myzod.ValidationError) {
-      return sendErrorResponse(req, res, 400, error.message)
-    }
-    return sendErrorResponse(req, res, 400, 'Invalid path parameters')
+  const validation = pathSchema({ sessionId, guildId })
+  if (validation !== true) {
+    return sendErrorResponse(req, res, 400, validation?.[0]?.message || 'Invalid path parameters')
   }
 
   if (method === 'POST') {
@@ -70,7 +64,10 @@ async function handleCreateMix(
       }
     }
 
-    createMixSchema.parse(body)
+    const bodyValidation = createMixSchema(body)
+    if (bodyValidation !== true) {
+      return sendErrorResponse(req, res, 400, bodyValidation?.[0]?.message || 'Invalid parameters')
+    }
 
     const session = nodelink.sessions.get(sessionId)
     if (!session) {
@@ -127,9 +124,6 @@ async function handleCreateMix(
       201
     )
   } catch (error) {
-    if (error instanceof myzod.ValidationError) {
-      return sendErrorResponse(req, res, 400, error.message)
-    }
     logger('error', 'MixAPI', `Error creating mix: ${error.message}`)
     return sendErrorResponse(req, res, 500, error.message)
   }

--- a/src/api/sessions.id.players.js
+++ b/src/api/sessions.id.players.js
@@ -1,57 +1,60 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { decodeTrack, logger, sendErrorResponse } from '../utils.js'
 
-// Use unknown() instead of object for filters to preserve all properties
-const filtersSchema = myzod.unknown()
+const v = new Validator({ haltOnFirstError: true })
 
-const voiceStateSchema = myzod
-  .object({
-    token: myzod.string(),
-    endpoint: myzod.string(),
-    sessionId: myzod.string(),
-    channelId: myzod.string().optional()
-  })
-  .allowUnknownKeys()
+// Use unknown -> any in fastest-validator
+const filtersSchema = { type: 'any', optional: true }
 
-const updatePlayerTrackSchema = myzod
-  .object({
-    encoded: myzod.string().nullable().optional(),
-    identifier: myzod.string().optional(),
-    userData: myzod.unknown().optional()
-  })
-  .allowUnknownKeys()
+const voiceStateSchema = {
+  type: 'object',
+  props: {
+    token: { type: 'string', empty: false },
+    endpoint: { type: 'string', empty: false },
+    sessionId: { type: 'string', empty: false },
+    channelId: { type: 'string', optional: true }
+  },
+  $$strict: false
+}
 
-const updatePlayerSchema = myzod
-  .object({
-    track: updatePlayerTrackSchema.optional(),
-    nextTrack: updatePlayerTrackSchema.optional(),
-    encodedTrack: myzod.string().nullable().optional(),
-    position: myzod.number().min(0).optional(),
-    endTime: myzod.number().min(0).nullable().optional(),
-    volume: myzod.number().min(0).max(1000).optional(),
-    paused: myzod.boolean().optional(),
-    filters: filtersSchema.optional(),
-    fading: myzod.unknown().optional(),
-    voice: voiceStateSchema.optional(),
-    guildId: myzod.string().optional()
-  })
-  .allowUnknownKeys()
+const updatePlayerTrackSchema = {
+  type: 'object',
+  props: {
+    encoded: { type: 'string', nullable: true, optional: true },
+    identifier: { type: 'string', optional: true },
+    userData: { type: 'any', optional: true }
+  },
+  $$strict: false
+}
 
-const queryParamsSchema = myzod
-  .object({
-    noReplace: myzod.union([myzod.string(), myzod.null()]).optional()
-  })
-  .allowUnknownKeys()
+const updatePlayerSchema = v.compile({
+  track: { ...updatePlayerTrackSchema, optional: true },
+  nextTrack: { ...updatePlayerTrackSchema, optional: true },
+  encodedTrack: { type: 'string', nullable: true, optional: true },
+  position: { type: 'number', min: 0, optional: true },
+  endTime: { type: 'number', min: 0, nullable: true, optional: true },
+  volume: { type: 'number', min: 0, max: 1000, optional: true },
+  paused: { type: 'boolean', optional: true },
+  filters: filtersSchema,
+  fading: { type: 'any', optional: true },
+  voice: { ...voiceStateSchema, optional: true },
+  guildId: { type: 'string', optional: true },
+  $$strict: false
+})
 
-const pathSchema = myzod.object({
-  sessionId: myzod.string(),
-  guildId: myzod
-    .string()
-    .withPredicate(
-      (val) => /^\d{17,20}$/.test(val),
-      'guildId must be 17-20 digits'
-    )
-    .optional()
+const queryParamsSchema = v.compile({
+  noReplace: { type: 'string', nullable: true, optional: true },
+  $$strict: false
+})
+
+const pathSchema = v.compile({
+  sessionId: { type: 'string', empty: false },
+  guildId: {
+    type: 'string',
+    pattern: /^\d{17,20}$/,
+    optional: true,
+    messages: { stringPattern: 'guildId must be 17-20 digits' }
+  }
 })
 
 const sanitizeFadingConfig = (raw) => {
@@ -114,10 +117,10 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
     guildId: parts[5]
   }
 
-  const pathResult = pathSchema.try(pathParams)
+  const validation = pathSchema(pathParams)
 
-  if (pathResult instanceof myzod.ValidationError) {
-    const errorMessage = pathResult.message || 'Invalid path parameters'
+  if (validation !== true) {
+    const errorMessage = validation?.[0]?.message || 'Invalid path parameters'
     logger('warn', 'PlayerUpdate', `Invalid path parameters: ${errorMessage}`)
     return sendErrorResponse(
       req,
@@ -129,7 +132,7 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
     )
   }
 
-  const { sessionId, guildId } = pathResult
+  const { sessionId, guildId } = pathParams
   const session = nodelink.sessions.get(sessionId)
 
   if (!session) {
@@ -198,10 +201,10 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
       }
 
       if (req.method === 'PATCH') {
-        const bodyResult = updatePlayerSchema.try(req.body)
+        const bodyValidation = updatePlayerSchema(req.body)
 
-        if (bodyResult instanceof myzod.ValidationError) {
-          const errorMessage = bodyResult.message || 'Invalid payload'
+        if (bodyValidation !== true) {
+          const errorMessage = bodyValidation?.[0]?.message || 'Invalid payload'
           logger(
             'warn',
             'PlayerUpdate',
@@ -217,24 +220,24 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
           )
         }
 
-        const payload = bodyResult
+        const payload = req.body
 
-        const queryResult = queryParamsSchema.try({
+        const queryValidation = queryParamsSchema({
           noReplace: parsedUrl.searchParams.get('noReplace')
         })
 
-        if (queryResult instanceof myzod.ValidationError) {
+        if (queryValidation !== true) {
           return sendErrorResponse(
             req,
             res,
             400,
             'Bad Request',
-            queryResult.message,
+            queryValidation?.[0]?.message || 'Invalid query parameters',
             parsedUrl.pathname
           )
         }
 
-        const noReplace = queryResult.noReplace === 'true'
+        const noReplace = parsedUrl.searchParams.get('noReplace') === 'true'
 
         logger(
           'debug',

--- a/src/api/trackstream.js
+++ b/src/api/trackstream.js
@@ -1,8 +1,18 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { decodeTrack, logger, sendErrorResponse } from '../utils.js'
 
-const trackStreamSchema = myzod.object({
-  encodedTrack: myzod.string()
+const v = new Validator({ haltOnFirstError: true })
+
+const trackStreamSchema = v.compile({
+  encodedTrack: {
+    type: 'string',
+    empty: false,
+    messages: {
+      required: 'Missing encodedTrack parameter.',
+      string: 'Missing encodedTrack parameter.',
+      stringEmpty: 'Missing encodedTrack parameter.'
+    }
+  }
 })
 
 async function handler(nodelink, req, res, sendResponse, parsedUrl) {
@@ -17,16 +27,18 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
     )
   }
 
-  const result = trackStreamSchema.try({
-    encodedTrack: parsedUrl.searchParams.get('encodedTrack')
-  })
+  const data = {
+    encodedTrack: parsedUrl.searchParams.get('encodedTrack') ?? undefined
+  }
+
+  const validation = trackStreamSchema(data)
 
   const itag = parsedUrl.searchParams.get('itag')
     ? Number(parsedUrl.searchParams.get('itag'))
     : null
 
-  if (result instanceof myzod.ValidationError) {
-    const errorMessage = result.message || 'Missing encodedTrack parameter.'
+  if (validation !== true) {
+    const errorMessage = validation?.[0]?.message || 'Missing encodedTrack parameter.'
     return sendErrorResponse(
       req,
       res,
@@ -37,7 +49,7 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
     )
   }
 
-  const encodedTrack = result.encodedTrack.replace(/ /g, '+')
+  const encodedTrack = data.encodedTrack.replace(/ /g, '+')
 
   try {
     const decodedTrack = decodeTrack(encodedTrack)

--- a/src/api/youtube.config.js
+++ b/src/api/youtube.config.js
@@ -1,13 +1,14 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import OAuth from '../sources/youtube/OAuth.js'
 import { logger, sendErrorResponse } from '../utils.js'
 
-const configSchema = myzod
-  .object({
-    refreshToken: myzod.string().min(1).optional(),
-    visitorData: myzod.string().min(1).optional()
-  })
-  .allowUnknownKeys()
+const v = new Validator({ haltOnFirstError: true })
+
+const configSchema = v.compile({
+  refreshToken: { type: 'string', min: 1, optional: true },
+  visitorData: { type: 'string', min: 1, optional: true },
+  $$strict: false
+})
 
 function maskString(str, visibleChars = 5) {
   if (!str) return null
@@ -70,20 +71,20 @@ async function handler(nodelink, req, res, sendResponse, parsedUrl) {
   }
 
   if (req.method === 'PATCH') {
-    const result = configSchema.try(req.body)
+    const validation = configSchema(req.body)
 
-    if (result instanceof myzod.ValidationError) {
+    if (validation !== true) {
       return sendErrorResponse(
         req,
         res,
         400,
         'Bad Request',
-        result.message,
+        validation?.[0]?.message || 'Invalid parameters',
         parsedUrl.pathname
       )
     }
 
-    const { refreshToken, visitorData } = result
+    const { refreshToken, visitorData } = req.body
 
     if (!refreshToken && !visitorData) {
       return sendErrorResponse(

--- a/src/api/youtube.oauth.js
+++ b/src/api/youtube.oauth.js
@@ -1,12 +1,10 @@
-import myzod from 'myzod'
+import Validator from 'fastest-validator'
 import { logger, makeRequest, sendErrorResponse } from '../utils.js'
 
-const CLIENT_ID =
-  '861556708454-d6dlm3lh05idd8npek18k6be8ba3oc68.apps.googleusercontent.com'
-const CLIENT_SECRET = 'SboVhoG9s0rNafixCSGGKXAT'
+const v = new Validator({ haltOnFirstError: true })
 
-const _schema = myzod.object({
-  refreshToken: myzod.string().min(1)
+const refreshTokenSchema = v.compile({
+  refreshToken: { type: 'string', min: 1, empty: false }
 })
 
 async function handler(_nodelink, req, res, sendResponse, parsedUrl) {
@@ -21,13 +19,15 @@ async function handler(_nodelink, req, res, sendResponse, parsedUrl) {
     }
   }
 
-  if (!refreshToken) {
+  const validation = refreshTokenSchema({ refreshToken: refreshToken ?? undefined })
+
+  if (validation !== true) {
     return sendErrorResponse(
       req,
       res,
       400,
       'Bad Request',
-      'Missing refreshToken parameter.',
+      validation?.[0]?.message || 'Missing refreshToken parameter.',
       parsedUrl.pathname
     )
   }


### PR DESCRIPTION
## Changes

This lib allows compiling, so it generates a javascript function for the schema validation, making it around 3.4x faster for validating.

## Why 

Improves the overall response of nodelink into its api that requires validations (loadtracks, encodetrack, etc)

## Checkmarks

- [X] The modified endpoints have been tested.
- [X] Used the same indentation as the rest of the project.
- [X] Still compatible with LavaLink clients.

## Additional information

Mini benchmark i did for validating:

Iterations: 1.000.000

--- VALID DATA RESULTS ---
myzod: 384.39ms | Heap: 6.09MB
fastest-validator: 133.09ms | Heap: 5.98MB

--- INVALID DATA RESULTS ---
myzod: 33557.16ms
fastest-validator: 931.37ms