### PR TITLE
improve: Soundcloud now rejects tracks that resolve to 30s preview

### DIFF
--- a/src/sources/soundcloud.js
+++ b/src/sources/soundcloud.js
@@ -743,6 +743,10 @@ export default class SoundCloudSource {
     if (!finalUrl) {
       return this._buildException('Failed to resolve stream URL')
     }
+    
+    if (finalUrl.includes('cf-preview-media.sndcdn.com') || finalUrl.includes('/preview/')) {
+  return this._buildException('Track only has preview URL')
+    }
 
     const mimeType = selected.format?.mime_type?.toLowerCase() ?? ''
     const protocol = selected.format?.protocol ?? 'progressive'


### PR DESCRIPTION
## Changes

Soundcloud now checks if transcoded url resolves to preview url if yes then rejects it

## Why 

Self explanatory 

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information
 Reproduce the preview url  problem with https://soundcloud.com/nayel100455/roop
