### PR TITLE
improve: migrate config validation to rule-based manager -WoC

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ import type {
 import type { ClientInfo, IPCMessage, ReqShim } from './typings/shared.types.ts'
 import { parseVoiceFrameHeader } from './voice/voiceFrames.ts'
 import { createVoiceRelay } from './voice/voiceRelay.ts'
+import ConfigValidationManager from './managers/configValidationManager.ts'
 
 type RequestHandlerType = typeof import('./api/index.ts').default
 let requestHandlerPromise: Promise<RequestHandlerType> | null = null
@@ -664,13 +665,8 @@ class NodelinkServer extends EventEmitter {
    * @internal
    */
   _validateConfig(): void {
-    const validateNonNegativeInt = (value: number, path: string): void =>
-      validateProperty(
-        value,
-        path,
-        'integer >= 0',
-        (v: number) => Number.isInteger(v) && v >= 0
-      )
+    const manager = new ConfigValidationManager(this.options)
+    manager.validate()
 
     const validatePositiveInt = (value: number, path: string): void =>
       validateProperty(
@@ -679,141 +675,6 @@ class NodelinkServer extends EventEmitter {
         'integer > 0',
         (v: number) => Number.isInteger(v) && v > 0
       )
-
-    validateProperty(
-      this.options.server.port,
-      'server.port',
-      'integer between 1 and 65535',
-      (value: number) => Number.isInteger(value) && value >= 1 && value <= 65535
-    )
-
-    validateProperty(
-      this.options.server.host,
-      'server.host',
-      'string',
-      (value: string) => typeof value === 'string'
-    )
-
-    validateProperty(
-      this.options.playerUpdateInterval,
-      'playerUpdateInterval',
-      'integer between 250 and 60000 (milliseconds)',
-      (value: number) =>
-        Number.isInteger(value) && value >= 250 && value <= 60000
-    )
-
-    validateProperty(
-      this.options.maxSearchResults,
-      'maxSearchResults',
-      'integer between 1 and 100',
-      (value: number) => Number.isInteger(value) && value >= 1 && value <= 100
-    )
-
-    validateProperty(
-      this.options.maxAlbumPlaylistLength,
-      'maxAlbumPlaylistLength',
-      'integer between 1 and 500',
-      (value: number) => Number.isInteger(value) && value >= 1 && value <= 500
-    )
-
-    validateProperty(
-      this.options.trackStuckThresholdMs,
-      'trackStuckThresholdMs',
-      'integer >= 1000 (milliseconds)',
-      (value: number) => Number.isInteger(value) && value >= 1000
-    )
-
-    validateProperty(
-      this.options.zombieThresholdMs,
-      'zombieThresholdMs',
-      `integer > trackStuckThresholdMs (${this.options.trackStuckThresholdMs})`,
-      (value: number) =>
-        Number.isInteger(value) && value > this.options.trackStuckThresholdMs
-    )
-
-    validateNonNegativeInt(this.options.cluster.workers, 'cluster.workers')
-
-    validateProperty(
-      this.options.cluster.minWorkers,
-      'cluster.minWorkers',
-      this.options.cluster.workers === 0
-        ? 'integer >= 0 (workers auto-scaled)'
-        : `integer between 0 and ${this.options.cluster.workers}`,
-      (value: number) =>
-        Number.isInteger(value) &&
-        value >= 0 &&
-        (this.options.cluster.workers === 0 ||
-          value <= this.options.cluster.workers)
-    )
-
-    validateProperty(
-      this.options.defaultSearchSource,
-      'defaultSearchSource',
-      'key or array of keys of enabled sources in config.sources',
-      (v: string | string[]) => {
-        const sources = Array.isArray(v) ? v : [v]
-        return sources.every(
-          (s) =>
-            typeof s === 'string' &&
-            this.options.sources &&
-            Boolean(
-              this.options.sources[s as keyof typeof this.options.sources]
-                ?.enabled
-            )
-        )
-      }
-    )
-
-    validateProperty(
-      this.options.audio.quality,
-      'audio.quality',
-      "one of ['high', 'medium', 'low', 'lowest']",
-      (v: string) => ['high', 'medium', 'low', 'lowest'].includes(v)
-    )
-
-    validateProperty(
-      this.options.audio.resamplingQuality,
-      'audio.resamplingQuality',
-      "one of ['best', 'medium', 'fastest', 'zero', 'linear']",
-      (v: string) => ['best', 'medium', 'fastest', 'zero', 'linear'].includes(v)
-    )
-
-    validateProperty(
-      this.options.audio.loudnessNormalizer,
-      'audio.loudnessNormalizer',
-      'boolean',
-      (v: boolean) => typeof v === 'boolean'
-    )
-
-    validateProperty(
-      this.options.audio.lookaheadMs,
-      'audio.lookaheadMs',
-      'number >= 0',
-      (v: number) => typeof v === 'number' && v >= 0
-    )
-
-    validateProperty(
-      this.options.audio.gateThresholdLUFS,
-      'audio.gateThresholdLUFS',
-      'number <= 0',
-      (v: number) => typeof v === 'number' && v <= 0
-    )
-
-    validateProperty(
-      this.options.routePlanner?.strategy,
-      'routePlanner.strategy',
-      "one of ['RotateOnBan', 'RoundRobin', 'LoadBalance']",
-      (v: string) =>
-        typeof v === 'string' &&
-        ['RotateOnBan', 'RoundRobin', 'LoadBalance'].includes(v)
-    )
-
-    if (this.options.routePlanner?.bannedIpCooldown !== undefined) {
-      validatePositiveInt(
-        this.options.routePlanner.bannedIpCooldown,
-        'routePlanner.bannedIpCooldown'
-      )
-    }
 
     const rateLimitSections = [
       'global',
@@ -860,140 +721,6 @@ class NodelinkServer extends EventEmitter {
             value <= parentConfig.maxRequests
         )
       }
-    }
-
-    const spotify = this.options.sources?.spotify
-    const applemusic = this.options.sources?.applemusic
-    const tidal = this.options.sources?.tidal
-    const jiosaavn = this.options.sources?.jiosaavn
-    const audius = this.options.sources?.audius
-
-    if (spotify?.enabled) {
-      validateNonNegativeInt(
-        spotify.playlistLoadLimit,
-        'sources.spotify.playlistLoadLimit'
-      )
-
-      validateNonNegativeInt(
-        spotify.albumLoadLimit,
-        'sources.spotify.albumLoadLimit'
-      )
-
-      validatePositiveInt(
-        spotify.playlistPageLoadConcurrency,
-        'sources.spotify.playlistPageLoadConcurrency'
-      )
-
-      validatePositiveInt(
-        spotify.albumPageLoadConcurrency,
-        'sources.spotify.albumPageLoadConcurrency'
-      )
-
-      const credsComplete =
-        Boolean(spotify.clientId) === Boolean(spotify.clientSecret)
-
-      validateProperty(
-        credsComplete,
-        'sources.spotify.credentials',
-        'clientId and clientSecret must be set together',
-        (v: boolean) => v === true
-      )
-    }
-
-    if (applemusic?.enabled) {
-      validateNonNegativeInt(
-        applemusic.playlistLoadLimit,
-        'sources.applemusic.playlistLoadLimit'
-      )
-
-      validateNonNegativeInt(
-        applemusic.albumLoadLimit,
-        'sources.applemusic.albumLoadLimit'
-      )
-
-      validatePositiveInt(
-        applemusic.playlistPageLoadConcurrency,
-        'sources.applemusic.playlistPageLoadConcurrency'
-      )
-
-      validatePositiveInt(
-        applemusic.albumPageLoadConcurrency,
-        'sources.applemusic.albumPageLoadConcurrency'
-      )
-    }
-
-    if (tidal?.enabled) {
-      validateNonNegativeInt(
-        tidal.playlistLoadLimit,
-        'sources.tidal.playlistLoadLimit'
-      )
-
-      validatePositiveInt(
-        tidal.playlistPageLoadConcurrency,
-        'sources.tidal.playlistPageLoadConcurrency'
-      )
-
-      if (tidal.token !== undefined) {
-        validateProperty(
-          tidal.token,
-          'sources.tidal.token',
-          'string (non-whitespace if provided)',
-          (v: string) =>
-            typeof v === 'string' && (v === '' || v.trim().length > 0)
-        )
-      }
-
-      if (audius?.enabled) {
-        if (
-          audius?.appName !== undefined &&
-          typeof audius?.appName !== 'string'
-        ) {
-          throw new Error('sources.audius.appName must be a string')
-        }
-
-        if (
-          audius?.apiKey !== undefined &&
-          typeof audius?.apiKey !== 'string'
-        ) {
-          throw new Error('sources.audius.apiKey must be a string')
-        }
-
-        if (
-          audius?.apiSecret !== undefined &&
-          typeof audius?.apiSecret !== 'string'
-        ) {
-          throw new Error('sources.audius.apiSecret must be a string')
-        }
-
-        validateNonNegativeInt(
-          audius?.playlistLoadLimit,
-          'sources.audius.playlistLoadLimit'
-        )
-
-        validateNonNegativeInt(
-          audius?.albumLoadLimit,
-          'sources.audius.albumLoadLimit'
-        )
-      }
-    }
-
-    if (jiosaavn?.enabled) {
-      validateNonNegativeInt(
-        jiosaavn.playlistLoadLimit,
-        'sources.jiosaavn.playlistLoadLimit'
-      )
-
-      validateNonNegativeInt(
-        jiosaavn.artistLoadLimit,
-        'sources.jiosaavn.artistLoadLimit'
-      )
-
-      validateProperty(
-        jiosaavn.playlistLoadLimit,
-        'sources.jiosaavn.playlistLoadLimit',
-        `integer >= artistLoadLimit (${jiosaavn.artistLoadLimit})`,
-        (v: number) => v >= jiosaavn.artistLoadLimit
-      )
     }
   }
 

--- a/src/managers/configValidationManager.ts
+++ b/src/managers/configValidationManager.ts
@@ -1,0 +1,457 @@
+import { validateProperty } from '../utils.ts'
+
+type ValidationRule<T = any> = {
+  path: string
+  expected: string
+  get: () => T
+  validate: (value: T) => boolean
+}
+
+export default class ConfigValidationManager {
+  constructor(private options: any) { }
+
+  validate(): void {
+    const errors: string[] = []
+
+    const domains = [
+      () => this.validateServer(),
+      () => this.validateCluster(),
+      () => this.validateAudio(),
+      () => this.validateSources(),
+      () => this.validatePlayback(),
+      () => this.validateRoutePlanner(),
+      () => this.validateSearch()
+    ]
+
+    for (const validateDomain of domains) {
+      try {
+        validateDomain()
+      } catch (err: any) {
+        errors.push(err.message)
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new Error(
+        'Configuration errors:\n\n' + errors.join('\n\n')
+      )
+    }
+  }
+
+
+
+  // ===== DOMAINS =====
+
+  private validateServer(): void {
+    const server = this.options.server
+
+    const rules: ValidationRule[] = [
+      this.nonEmptyStringRule('server.host', () => server?.host),
+
+      this.intRangeRule('server.port', () => server?.port, 1, 65535),
+
+      this.nonEmptyStringRule('server.password', () => server?.password),
+
+      this.booleanRule('server.useBunServer', () => server?.useBunServer)
+    ]
+
+    this.runRules(rules)
+  }
+
+  private validateCluster(): void {
+    const workers = this.options.cluster?.workers
+
+    const rules: ValidationRule[] = [
+      this.nonNegativeIntRule('cluster.workers', () => workers),
+
+      this.nonNegativeIntRule(
+        'cluster.minWorkers',
+        () => this.options.cluster?.minWorkers
+      ),
+
+      {
+        path: 'cluster.minWorkers',
+        expected:
+          workers === 0
+            ? 'auto-scaled workers'
+            : `<= cluster.workers (${workers})`,
+        get: () => this.options.cluster?.minWorkers,
+        validate: (v: number) =>
+          Number.isInteger(v) &&
+          (workers === 0 || v <= workers)
+
+      }
+    ]
+
+    this.runRules(rules)
+  }
+
+  private validatePlayback(): void {
+    const trackStuck = this.options.trackStuckThresholdMs
+
+    const rules: ValidationRule[] = [
+      this.intRangeRule(
+        'playerUpdateInterval',
+        () => this.options.playerUpdateInterval,
+        250,
+        60000
+      ),
+
+      {
+        path: 'trackStuckThresholdMs',
+        expected: 'integer >= 1000 (milliseconds)',
+        get: () => trackStuck,
+        validate: (v: number) => Number.isInteger(v) && v >= 1000
+      },
+
+      {
+        path: 'zombieThresholdMs',
+        expected: `integer > trackStuckThresholdMs (${trackStuck})`,
+        get: () => this.options.zombieThresholdMs,
+        validate: (v: number) => Number.isInteger(v) && v > trackStuck
+      }
+    ]
+
+    this.runRules(rules)
+  }
+
+  private validateAudio(): void {
+    const audio = this.options.audio
+    const rules: ValidationRule[] = [
+      this.booleanRule(
+        'audio.loudnessNormalizer',
+        () => audio?.loudnessNormalizer
+      ),
+
+      this.nonNegativeIntRule('audio.lookaheadMs', () => audio?.lookaheadMs),
+
+      {
+        path: 'audio.gateThresholdLUFS',
+        expected: 'number <= 0',
+        get: () => audio?.gateThresholdLUFS,
+        validate: (v: number) => typeof v === 'number' && v <= 0
+      },
+
+      this.enumRule('audio.quality', () => audio?.quality, [
+        'high',
+        'medium',
+        'low',
+        'lowest'
+      ] as const),
+
+      this.enumRule('audio.resamplingQuality', () => audio?.resamplingQuality, [
+        'best',
+        'medium',
+        'fastest',
+        'zero',
+        'linear'
+      ] as const)
+    ]
+
+    this.runRules(rules)
+  }
+
+  private validateSources(): void {
+    const sources = this.options.sources
+    if (!sources) return
+
+    const rules: ValidationRule[] = []
+
+    const spotify = sources.spotify
+    const applemusic = sources.applemusic
+    const tidal = sources.tidal
+    const jiosaavn = sources.jiosaavn
+    const audius = sources.audius
+
+    if (spotify?.enabled) {
+      rules.push(
+        this.nonNegativeIntRule(
+          'sources.spotify.playlistLoadLimit',
+          () => spotify.playlistLoadLimit
+        ),
+        this.nonNegativeIntRule(
+          'sources.spotify.albumLoadLimit',
+          () => spotify.albumLoadLimit
+        ),
+        this.positiveIntRule(
+          'sources.spotify.playlistPageLoadConcurrency',
+          () => spotify.playlistPageLoadConcurrency
+        ),
+        this.positiveIntRule(
+          'sources.spotify.albumPageLoadConcurrency',
+          () => spotify.albumPageLoadConcurrency
+        ),
+        {
+          path: 'sources.spotify.credentials',
+          expected: 'clientId and clientSecret must be set together',
+          get: () =>
+            Boolean(spotify.clientId) === Boolean(spotify.clientSecret),
+          validate: (v: boolean) => v === true
+        }
+      )
+    }
+
+    if (applemusic?.enabled) {
+      rules.push(
+        this.nonNegativeIntRule(
+          'sources.applemusic.playlistLoadLimit',
+          () => applemusic.playlistLoadLimit
+        ),
+        this.nonNegativeIntRule(
+          'sources.applemusic.albumLoadLimit',
+          () => applemusic.albumLoadLimit
+        ),
+        this.positiveIntRule(
+          'sources.applemusic.playlistPageLoadConcurrency',
+          () => applemusic.playlistPageLoadConcurrency
+        ),
+        this.positiveIntRule(
+          'sources.applemusic.albumPageLoadConcurrency',
+          () => applemusic.albumPageLoadConcurrency
+        )
+      )
+    }
+
+    if (tidal?.enabled) {
+      rules.push(
+        this.nonNegativeIntRule(
+          'sources.tidal.playlistLoadLimit',
+          () => tidal.playlistLoadLimit
+        ),
+        this.positiveIntRule(
+          'sources.tidal.playlistPageLoadConcurrency',
+          () => tidal.playlistPageLoadConcurrency
+        )
+      )
+
+      if (tidal.token !== undefined) {
+        rules.push({
+          path: 'sources.tidal.token',
+          expected: 'string (non-whitespace if provided)',
+          get: () => tidal.token,
+          validate: (v: string) =>
+            typeof v === 'string' && (v === '' || v.trim().length > 0)
+        })
+      }
+    }
+
+    if (audius?.enabled) {
+      rules.push(
+        {
+          path: 'sources.audius.appName',
+          expected: 'string',
+          get: () => audius.appName,
+          validate: (v: string) => v === undefined || typeof v === 'string'
+        },
+        {
+          path: 'sources.audius.apiKey',
+          expected: 'string',
+          get: () => audius.apiKey,
+          validate: (v: string) => v === undefined || typeof v === 'string'
+        },
+        {
+          path: 'sources.audius.apiSecret',
+          expected: 'string',
+          get: () => audius.apiSecret,
+          validate: (v: string) => v === undefined || typeof v === 'string'
+        },
+        this.nonNegativeIntRule(
+          'sources.audius.playlistLoadLimit',
+          () => audius.playlistLoadLimit
+        ),
+        this.nonNegativeIntRule(
+          'sources.audius.albumLoadLimit',
+          () => audius.albumLoadLimit
+        )
+      )
+    }
+
+    if (jiosaavn?.enabled) {
+      rules.push(
+        this.nonNegativeIntRule(
+          'sources.jiosaavn.playlistLoadLimit',
+          () => jiosaavn.playlistLoadLimit
+        ),
+        this.nonNegativeIntRule(
+          'sources.jiosaavn.artistLoadLimit',
+          () => jiosaavn.artistLoadLimit
+        ),
+        {
+          path: 'sources.jiosaavn.playlistLoadLimit',
+          expected: `integer >= artistLoadLimit (${jiosaavn.artistLoadLimit})`,
+          get: () => jiosaavn.playlistLoadLimit,
+          validate: (v: number) => v >= jiosaavn.artistLoadLimit
+        }
+      )
+    }
+
+    this.runRules(rules)
+  }
+
+  private validateSearch(): void {
+    const rules: ValidationRule[] = []
+
+    rules.push(
+      this.intRangeRule(
+        'maxSearchResults',
+        () => this.options.maxSearchResults,
+        1,
+        100
+      )
+    )
+
+    rules.push(
+      this.intRangeRule(
+        'maxAlbumPlaylistLength',
+        () => this.options.maxAlbumPlaylistLength,
+        1,
+        500
+      )
+    )
+
+    rules.push({
+      path: 'defaultSearchSource',
+      expected:
+        'string or non-empty string[] of enabled source names in config.sources',
+      get: () => this.options.defaultSearchSource,
+      validate: (v: any) => {
+        const sources = this.options.sources
+        if (!sources) return false
+
+        if (typeof v === 'string') {
+          return sources[v]?.enabled === true
+        }
+
+        if (Array.isArray(v)) {
+          if (v.length === 0) return false
+
+          return v.every(
+            (name: any) =>
+              typeof name === 'string' && sources[name]?.enabled === true
+          )
+        }
+
+        return false
+      }
+    })
+
+    this.runRules(rules)
+  }
+
+  private validateRoutePlanner(): void {
+    const routePlanner = this.options.routePlanner
+    if (!routePlanner) return
+
+    const rules: ValidationRule[] = []
+
+    rules.push(
+      this.enumRule('routePlanner.strategy', () => routePlanner.strategy, [
+        'RotateOnBan',
+        'RoundRobin',
+        'LoadBalance'
+      ] as const)
+    )
+
+    if (routePlanner.bannedIpCooldown !== undefined) {
+      rules.push(
+        this.positiveIntRule(
+          'routePlanner.bannedIpCooldown',
+          () => routePlanner.bannedIpCooldown
+        )
+      )
+    }
+
+    this.runRules(rules)
+  }
+
+  private runRules(rules: ValidationRule[]): void {
+    const errors: string[] = []
+
+    for (const rule of rules) {
+      try {
+        validateProperty(rule.get(), rule.path, rule.expected, rule.validate)
+      } catch (err: any) {
+        errors.push(err.message)
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new Error('Configuration errors:\n\n' + errors.join('\n\n'))
+    }
+  }
+
+  private nonNegativeIntRule(
+    path: string,
+    get: () => number
+  ): ValidationRule<number> {
+    return {
+      path,
+      expected: 'integer >= 0',
+      get,
+      validate: (v) => Number.isInteger(v) && v >= 0
+    }
+  }
+
+  private positiveIntRule(
+    path: string,
+    get: () => number
+  ): ValidationRule<number> {
+    return {
+      path,
+      expected: 'integer > 0',
+      get,
+      validate: (v) => Number.isInteger(v) && v > 0
+    }
+  }
+
+  private intRangeRule(
+    path: string,
+    get: () => number,
+    min: number,
+    max: number
+  ): ValidationRule<number> {
+    return {
+      path,
+      expected: `integer between ${min} and ${max}`,
+      get,
+      validate: (v) => Number.isInteger(v) && v >= min && v <= max
+    }
+  }
+
+  private booleanRule(
+    path: string,
+    get: () => boolean
+  ): ValidationRule<boolean> {
+    return {
+      path,
+      expected: 'boolean',
+      get,
+      validate: (v) => typeof v === 'boolean'
+    }
+  }
+
+  private nonEmptyStringRule(
+    path: string,
+    get: () => string
+  ): ValidationRule<string> {
+    return {
+      path,
+      expected: 'non-empty string',
+      get,
+      validate: (v) => typeof v === 'string' && v.trim().length > 0
+    }
+  }
+
+  private enumRule<T>(
+    path: string,
+    get: () => T,
+    allowed: readonly T[]
+  ): ValidationRule<T> {
+    return {
+      path,
+      expected: `one of [${allowed.join(', ')}]`,
+      get,
+      validate: (v) => allowed.includes(v)
+    }
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -362,10 +362,18 @@ function validateProperty<T>(
   expected: string,
   validator: (value: T) => boolean
 ): void {
+  const received =
+    value === undefined
+      ? 'undefined'
+      : value === null
+        ? 'null'
+        : `${JSON.stringify(value)} (${typeof value})`
+
   if (value === undefined || value === null) {
     throw new Error(
       `Configuration error:\n` +
         `- Property: ${path}\n` +
+        `- Received: ${received}\n` +
         `- Problem: missing required value\n` +
         `- Expected: ${expected}\n\n` +
         `Please define ${path} in your config.js file.`
@@ -376,7 +384,7 @@ function validateProperty<T>(
     throw new Error(
       `Configuration error:\n` +
         `- Property: ${path}\n` +
-        `- Received: ${JSON.stringify(value)} (${typeof value})\n` +
+        `- Received: ${received}\n` +
         `- Expected: ${expected}`
     )
   }


### PR DESCRIPTION
## Changes

- Migrates config validation into a dedicated ConfigValidationManager
- Introduces rule-based validation abstraction
- Aggregates domain-specific validation errors

## Why 

Write here why you think this should be merged

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information

If you have any additional information, write it here

any usages inside the validation manager will be replaced with safer types