### PR TITLE
Add ecosystem for quick pm2 launch

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,11 @@
+// pm2 start ecosystem.config.cjs
+module.exports = {
+    apps: [
+        {
+            name: "Nodelink",
+            script: "npm",
+            args: ["run", "start"],
+            cwd: __dirname,
+        },
+    ],
+};


### PR DESCRIPTION
A Sample ecosystem.config.cjs file, so they can just run
```
pm2 start ecosystem.config.cjs
```
to make a "deployment" using pm2.

What is pm2? https://pm2.io/
PM2 is a process manager, allowing you to run any process in the background, similar to screen.
But it is modern, built for node/js project(s) and allows you to run BINARYS without virtualization needs.
