### PR TITLE
fix: align seek position and startTime handling

### DIFF
--- a/src/api/sessions.id.players.ts
+++ b/src/api/sessions.id.players.ts
@@ -73,6 +73,11 @@ interface PlayerPatchPayload {
   position?: number
 
   /**
+   * Legacy alias used by some clients for `position`.
+   */
+  startTime?: number
+
+  /**
    * Optional playback end time in milliseconds.
    */
   endTime?: number | null
@@ -186,6 +191,11 @@ interface PlayerPatchBodyInput {
    * Candidate seek position.
    */
   position?: number
+
+  /**
+   * Candidate legacy seek position alias.
+   */
+  startTime?: number
 
   /**
    * Candidate playback end time.
@@ -768,7 +778,7 @@ function getPlayerPatchPayload(
     return null
   }
 
-  const position = payload.position
+  const position = payload.position ?? payload.startTime
   if (
     position !== undefined &&
     (typeof position !== 'number' || !Number.isFinite(position) || position < 0)
@@ -843,6 +853,10 @@ function getPlayerPatchPayload(
           ? null
           : undefined,
     position,
+    startTime:
+      typeof payload.startTime === 'number' && Number.isFinite(payload.startTime)
+        ? payload.startTime
+        : undefined,
     endTime:
       typeof endTime === 'number'
         ? endTime

--- a/src/managers/sourceManager.ts
+++ b/src/managers/sourceManager.ts
@@ -584,11 +584,29 @@ export default class SourcesManager implements SourceManagerLike {
         `Source ${track.sourceName} not found or does not support loadStream`
       )
     }
+    const normalizedAdditionalData = {
+      ...(additionalData ?? {})
+    } as Record<string, unknown> & { startTime?: number; position?: number }
+
+    if (
+      typeof normalizedAdditionalData.startTime === 'number' &&
+      typeof normalizedAdditionalData.position !== 'number'
+    ) {
+      normalizedAdditionalData.position = normalizedAdditionalData.startTime
+    }
+
+    if (
+      typeof normalizedAdditionalData.position === 'number' &&
+      typeof normalizedAdditionalData.startTime !== 'number'
+    ) {
+      normalizedAdditionalData.startTime = normalizedAdditionalData.position
+    }
+
     return (await instance.loadStream(
       track,
       url,
       protocol,
-      additionalData
+      normalizedAdditionalData
     )) as TrackStreamResult & { type?: string; exception?: { message: string } }
   }
 

--- a/src/playback/player.ts
+++ b/src/playback/player.ts
@@ -935,15 +935,24 @@ export class Player {
       return { exception: { message: 'Stream processor not initialized' } }
     }
 
-    const additionalData: Record<string, unknown> & { startTime?: number } = {
+    const additionalData: Record<string, unknown> & {
+      startTime?: number
+      position?: number
+      positionCallback?: (positionMs: number) => void
+    } = {
       ...urlData.additionalData
     }
-    if (startTime !== undefined) additionalData.startTime = startTime
-
-    urlData.additionalData = {
-      ...urlData.additionalData,
-      positionCallback: () => this._realPosition()
+    if (startTime !== undefined) {
+      additionalData.startTime = startTime
+      // Keep both keys for source compatibility while seek handling is unified.
+      additionalData.position = startTime
     }
+    additionalData.positionCallback = (positionMs: number) => {
+      if (!Number.isFinite(positionMs) || positionMs < 0) return
+      this.position = positionMs
+    }
+
+    urlData.additionalData = additionalData
 
     const track = urlData?.newTrack
       ? (urlData?.newTrack?.info as TrackInfoExtended)

--- a/src/playback/player.ts
+++ b/src/playback/player.ts
@@ -1467,6 +1467,9 @@ export class Player {
     this._isSeeking = true
     try {
       const sourceName = this.track.info.sourceName
+      const resolvedSourceName =
+        (this.streamInfo?.newTrack as { info?: { sourceName?: string } } | null)
+          ?.info?.sourceName ?? sourceName
       const unsupportedSources = ['local', 'deezer']
 
       let seekPromise: Promise<boolean>
@@ -1512,7 +1515,8 @@ export class Player {
       const hasSourceLoader = source && typeof source.loadStream === 'function'
       const canNativeSeek =
         !!hasSourceLoader &&
-        (this.streamInfo?.protocol === 'sabr' || sourceName === 'deezer')
+        (this.streamInfo?.protocol === 'sabr' ||
+          (sourceName === 'deezer' && resolvedSourceName === 'deezer'))
 
       if (forceLegacy) {
         seekPromise = this._legacySeek(
@@ -1525,7 +1529,7 @@ export class Player {
           endTime !== undefined ? endTime : this.track.endTime
         )
       } else if (
-        !unsupportedSources.includes(sourceName) &&
+        !unsupportedSources.includes(resolvedSourceName) &&
         this.streamInfo?.url &&
         this.streamInfo.protocol !== 'hls' &&
         this.streamInfo.protocol !== 'dash'

--- a/src/sources/youtube/YouTube.ts
+++ b/src/sources/youtube/YouTube.ts
@@ -2098,20 +2098,7 @@ export default class YouTubeSource {
     additionalData?: TrackUrlAdditionalData
   ): StreamResult {
     const stream = new PassThrough({ highWaterMark: CHUNK_SIZE * 2 })
-    const startTimeMs =
-      typeof additionalData?.startTime === 'number' ? additionalData.startTime : 0
-    const durationMs =
-      typeof decodedTrack.length === 'number' ? decodedTrack.length : 0
-    const requestedBytePosition =
-      startTimeMs > 0 && durationMs > 0
-        ? Math.floor(
-            (contentLength * Math.min(startTimeMs, durationMs)) / durationMs
-          )
-        : 0
-    let position = Math.max(
-      0,
-      Math.min(requestedBytePosition, Math.max(contentLength - 1, 0))
-    )
+    let position = 0
     let errors = 0
     let refreshes = 0
     let currentUrl = url

--- a/src/sources/youtube/YouTube.ts
+++ b/src/sources/youtube/YouTube.ts
@@ -2098,7 +2098,20 @@ export default class YouTubeSource {
     additionalData?: TrackUrlAdditionalData
   ): StreamResult {
     const stream = new PassThrough({ highWaterMark: CHUNK_SIZE * 2 })
-    let position = 0
+    const startTimeMs =
+      typeof additionalData?.startTime === 'number' ? additionalData.startTime : 0
+    const durationMs =
+      typeof decodedTrack.length === 'number' ? decodedTrack.length : 0
+    const requestedBytePosition =
+      startTimeMs > 0 && durationMs > 0
+        ? Math.floor(
+            (contentLength * Math.min(startTimeMs, durationMs)) / durationMs
+          )
+        : 0
+    let position = Math.max(
+      0,
+      Math.min(requestedBytePosition, Math.max(contentLength - 1, 0))
+    )
     let errors = 0
     let refreshes = 0
     let currentUrl = url

--- a/src/workers/main.ts
+++ b/src/workers/main.ts
@@ -1828,7 +1828,8 @@ async function startLoadStream(
 
   const additionalData = {
     ...(urlResult.additionalData || {}),
-    startTime: payload?.position || 0
+    startTime: payload?.position || 0,
+    position: payload?.position || 0
   }
 
   const fetched = (await nodelink.sources.getTrackStream(

--- a/src/workers/source.ts
+++ b/src/workers/source.ts
@@ -1333,7 +1333,8 @@ if (isMainThread) {
       } else {
         const additionalData = {
           ...(urlResult.additionalData || {}),
-          startTime: payload?.position || 0
+          startTime: payload?.position || 0,
+          position: payload?.position || 0
         }
 
         fetched =


### PR DESCRIPTION
Fix seeking issue. (untested yet)

seek requests were received, but the stream layer could lose the requested offset because position / startTime handling was inconsistent, so playback restarted at 0.
