### PR TITLE
feat(sessions): implement session resuming support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2216,7 +2216,12 @@ class NodelinkServer extends EventEmitter {
     if (msg.type === 'playerEvent') {
       const { sessionId, data } = msg.payload
       const session = this.sessions.get(sessionId)
-      session?.socket?.send(data)
+      // [feat] session-resuming-queue: queue events when session is paused with resuming enabled
+      if (session?.isPaused && session.resuming) {
+        session.eventQueue.push(data)
+      } else {
+        session?.socket?.send(data)
+      }
     } else if (msg.type === 'workerStats') {
       if (this.workerManager) {
         const worker = this.workerManager.workers.find(

--- a/src/managers/sessionManager.ts
+++ b/src/managers/sessionManager.ts
@@ -128,24 +128,31 @@ export default class SessionManager {
    * @param sessionId - The ID of the session to pause.
    */
   public pause(sessionId: string): void {
+    // [feat] session-resuming: guard double-pause and clear stale socket
+    if (this.resumableSessions.has(sessionId)) {
+      logger('debug', 'SessionManager', `Session ${sessionId} is already paused.`)
+      return
+    }
+
     const session = this.activeSessions.get(sessionId)
     if (!session) return
 
     logger(
       'info',
       'SessionManager',
-      `Pausing session ${sessionId} for ${session.timeout} seconds.`
+      `Pausing session ${sessionId} for resuming (timeout: ${session.timeout}s).`
     )
 
     this.activeSessions.delete(sessionId)
     session.isPaused = true
+    session.socket = null
     this.resumableSessions.set(sessionId, session)
 
     session.timeoutFuture = setTimeout(() => {
       logger(
         'info',
         'SessionManager',
-        `Session ${sessionId} resume timeout expired. Destroying.`
+        `Session ${sessionId} resume timeout expired after ${session.timeout}s. Destroying.`
       )
       this.resumableSessions.delete(sessionId)
       void this.destroy(session)


### PR DESCRIPTION
## Summary

Implements session resuming support compatible with the [Lavalink resuming spec](https://lavalink.dev/api/rest.html#update-session).

NodeLink already has the data model (`session.resuming`, `session.timeout`, `resumableSessions`, `pause()`, `resume()`) and the PATCH endpoint stores the values correctly. These fixes close the remaining gaps:

| Issue | Fix |
|---|---|
| `pause()` did not clear the stale socket → ghost sends to closed connection | Set `session.socket = null` on pause |
| Double-close events could reset the resume timer | Guard with `resumableSessions.has()` check |
| Events queued for all paused sessions regardless of `resuming` flag | Only queue when `session.resuming === true` |

## Flow

```
Client                                NodeLink
  │── PATCH /v4/sessions/:id ────────►│  session.resuming = true
  │   { resuming: true, timeout: 60 } │  session.timeout  = 60
  │◄─ { resuming: true, timeout: 60 } │
  │                                   │
  │  [connection drops]               │
  │                                   │  pause(): socket = null
  │                                   │  move to resumableSessions
  │                                   │  start 60 s destruction timer
  │                                   │  events → eventQueue
  │── WS connect + Session-ID ───────►│  resume(): restore socket
  │◄─ { op: ready, resumed: true }    │  flush eventQueue → new socket
```

## Checkmarks

- [ ] The modified endpoints have been tested.
- [ ] Used the same indentation as the rest of the project.
- [ ] Still compatible with LavaLink clients.