### PR TITLE
Comment out HiFi URL in default URLs

### DIFF
--- a/dist/src/sources/monochrome.js
+++ b/dist/src/sources/monochrome.js
@@ -43,7 +43,7 @@ class MonochromeSource {
             'https://singapore-1.monochrome.tf',
             'https://ohio-1.monochrome.tf',
             'https://frankfurt-1.monochrome.tf',
-            'https://hifi.geeked.wtf',
+           // 'https://hifi.geeked.wtf',
             'https://eu-central.monochrome.tf',
             'https://us-west.monochrome.tf',
             'https://api.monochrome.tf',

--- a/src/sources/monochrome.ts
+++ b/src/sources/monochrome.ts
@@ -67,7 +67,7 @@ class MonochromeSource implements SourceInstance {
       'https://singapore-1.monochrome.tf',
       'https://ohio-1.monochrome.tf',
       'https://frankfurt-1.monochrome.tf',
-      'https://hifi.geeked.wtf',
+     // 'https://hifi.geeked.wtf',
       'https://eu-central.monochrome.tf',
       'https://us-west.monochrome.tf',
       'https://api.monochrome.tf',


### PR DESCRIPTION
Comment out the HiFi URL in the default URLs list.

## Changes

Write here about the changes you've made

## Why 

Write here why you think this should be merged

## Checkmarks

- [x ] The modified endpoints have been tested.
- [x ] Used the same indentation as the rest of the project.
- [ x] Still compatible with LavaLink clients.

## Additional information

If you have any additional information, write it here

I removed the link https://hifi.geeked.wtf because it no longer exists and keeps giving an infinite source error and high RAM and CPU usage, and it won't play music.

<img width="1147" height="683" alt="image" src="https://github.com/user-attachments/assets/206d4593-8602-4c8c-a2ea-f232e20233d5" />

