### PR TITLE
docs: Remove deprecated version line

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   nodelink:
     build:


### PR DESCRIPTION
## Changes
Removing the version line in the docker-compose.yml


## Why 

This is a easy removal of that line, otherwise it throws a simple warning up telling users that this line is deprecated. 

## Checkmarks

- [X] The modified endpoints have been tested.
- [X] Used the same indentation as the rest of the project.
- [X] Still compatible with LavaLink clients.

## Additional information

N/A