### PR TITLE
fix(spotify): use search.maxResults configuration for search limit

### DIFF
--- a/src/sources/spotify.ts
+++ b/src/sources/spotify.ts
@@ -777,14 +777,7 @@ export default class SpotifySource implements SourceInstance {
       return this.getRecommendations(query)
 
     try {
-      let limit = this.config.playlistLoadLimit || 10
-
-      // fixes the error Argument <limit> for field /searchV2 cannot be greater than 1000
-      // this is a config issue from the user side, but if this can be used as a workaround,
-      // we set it to 10 to avoid the error :p.
-      if (limit > 999) {
-        limit = 10
-      }
+      let limit = this.nodelink.options.search.maxResults || 10
 
       // Priority 1: Internal Search (Rich nodes + Local matching)
       if (this.anonymousToken || this.config.sp_dc) {

--- a/src/sources/spotify.ts
+++ b/src/sources/spotify.ts
@@ -777,7 +777,7 @@ export default class SpotifySource implements SourceInstance {
       return this.getRecommendations(query)
 
     try {
-      let limit = this.nodelink.options.search.maxResults || 10
+      let limit = Math.min(Math.max(this.nodelink.options.search.maxResults ?? 10, 1), 50)
 
       // Priority 1: Internal Search (Rich nodes + Local matching)
       if (this.anonymousToken || this.config.sp_dc) {


### PR DESCRIPTION
## Changes

- Decoupled the Spotify search query limit parameter from the `playlistLoadLimit` configuration.
- Refactored the `search()` method in `src/sources/spotify.ts` to retrieve and use `this.nodelink.options.search.maxResults` (defaulting to 10) instead of `this.config.playlistLoadLimit`.

## Why 

The official Spotify text search query API calls (`/v1/search`) were incorrectly inheriting the `playlistLoadLimit` configuration, which is designed solely to limit the amount of pages loaded when fetching Spotify Playlists, Albums, or Artists.

If a user configured a low `playlistLoadLimit` (e.g., `1` or `2` to avoid massive playlist ingestion and API rate limits), text-based Spotify searches (`spsearch`) would yield only 1 or 2 results instead of the expected search result list count.

Standardizing on `search.maxResults` fixes this text search limitation bug and aligns the Spotify source's text search behavior with all other sources (such as Apple Music, Tidal, and Deezer) in NodeLink.

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information

This bug caused Discord music bots using NodeLink to always return only a single track choice when users searched by keyword using the Spotify source, if playlist loading restrictions were active.