### PR TITLE
update: readme & dockerfile to reflect new changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY --from=builder /app/node_modules ./node_modules
 # Copy the rest of the application source code
 # This includes the 'src' directory, default config, and package files for runtime information.
 COPY src/ ./src/
-COPY config.default.js ./config.default.js
+COPY config.default.ts ./config.default.ts
 COPY package.json ./package.json
 
 # Expose the port the application listens on (default is 3000 from config.default.js)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cd NodeLink
 npm install
 
 # Copy the default configuration file
-cp config.default.js config.js
+cp config.default.ts config.ts
 
 # Start the server
 npm run start
@@ -175,9 +175,10 @@ Internally, NodeLink combines native and WebAssembly modules for precise audio p
 - [`@ecliptia/faad2-wasm`](https://www.npmjs.com/package/@ecliptia/faad2-wasm) 💙
 - [`@ecliptia/seekable-stream`](https://github.com/1Lucas1apk/seekable-stream) 💙
 - [`@toddynnn/symphonia-decoder`](https://www.npmjs.com/package/@toddynnn/symphonia-decoder)
+- [`@toddynnn/voice-opus`](https://www.npmjs.com/package/@toddynnn/voice-opus)
 - [`mp4box`](https://www.npmjs.com/package/mp4box)
-- [`myzod`](https://www.npmjs.com/package/myzod)
-- [`toddy-mediaplex`](https://www.npmjs.com/package/toddy-mediaplex)
+- [`fastest-validator`](https://www.npmjs.com/package/fastest-validator)
+- [`proxy-agent`](https://www.npmjs.com/package/proxy-agent)
 
 **Optional Dependencies:**
 


### PR DESCRIPTION
## Changes

Updated the readme to reflect the current installed dependecies in the package.json (dev branch)
Updated the dockerfile to reflect the new config.default.ts file extension
Updated the readme to reflect the new config.default.ts and config.ts file extensions

## Why 

Since nodelink moved to typescript, updated readme and dockerfile switching the file extension to .ts, and also updated the dependencies list in readme.


## Checkmarks

- [ X ] The modified endpoints have been tested.
- [ X ] Used the same indentation as the rest of the project.
- [ X ] Still compatible with LavaLink clients.

## Additional information
