### PR TITLE
fix: reset fading start postion for gapless

### DIFF
--- a/dist/src/playback/player.js
+++ b/dist/src/playback/player.js
@@ -415,6 +415,7 @@ export class Player {
                 this._lyricsBasePosition = 0;
                 this._lyricsBasePackets =
                     this.connection?.statistics?.packetsExpected ?? 0;
+                this._fading('trackEndSchedule', { startPosition: 0 });
                 const oldStream = this.connection?.play(resource);
                 if (oldStream)
                     oldStream.destroy();

--- a/src/playback/player.ts
+++ b/src/playback/player.ts
@@ -628,6 +628,8 @@ export class Player {
         this._lyricsBasePackets =
           this.connection?.statistics?.packetsExpected ?? 0
 
+        this._fading('trackEndSchedule', { startPosition: 0 })
+
         const oldStream = this.connection?.play(resource as unknown)
         if (oldStream) oldStream.destroy()
         if (this._currentResource && this._currentResource !== resource) {


### PR DESCRIPTION
## Changes

gapless preload stops at 500 cuz of fading start position

## Why 

its pretty cool

## Checkmarks

- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information

good job
