### PR TITLE
fix: use seekable resource for seeks instead of refetching

### DIFF
--- a/src/playback/player.ts
+++ b/src/playback/player.ts
@@ -1663,20 +1663,65 @@ export class Player {
       return false
     }
 
-    const fetched = await this._fetchResource(
-      this.track.info,
-      urlData,
-      position
-    )
-    if ('exception' in fetched) {
-      const err = new Error(fetched.exception.message)
-      this._onError(err)
-      return false
+    const resolvedSourceName =
+      (urlData.newTrack as { info?: { sourceName?: string } } | undefined)?.info
+        ?.sourceName ?? this.track.info.sourceName
+    const unsupportedSeekSources = ['local', 'deezer']
+    const seekEligible =
+      position > 0 &&
+      !!urlData.url &&
+      !unsupportedSeekSources.includes(resolvedSourceName) &&
+      urlData.protocol !== 'sabr' &&
+      urlData.protocol !== 'hls' &&
+      urlData.protocol !== 'dash'
+    const seekUrl = seekEligible ? urlData.url : undefined
+    if (seekUrl) await getStreamProcessor()
+
+    let resource: AudioResource | undefined
+    if (seekUrl && createSeekeableAudioResource) {
+      logger(
+        'debug',
+        'Player',
+        `Seeking with Seekeable to ${position}ms for guild ${this.guildId}`
+      )
+      const seekResult = await createSeekeableAudioResource(
+        this.guildId,
+        seekUrl,
+        position,
+        this.track?.endTime,
+        this.nodelink,
+        this.filters,
+        this,
+        this.volumePercent / 100,
+        this.audioMixer
+      )
+      if ('exception' in seekResult) {
+        logger(
+          'error',
+          'Player',
+          `Seekeable resource creation failed for guild ${this.guildId}: ${seekResult.exception.message}. Falling back to old method.`
+        )
+      } else {
+        resource = seekResult
+      }
+    }
+
+    if (!resource) {
+      const fetched = await this._fetchResource(
+        this.track.info,
+        urlData,
+        position
+      )
+      if ('exception' in fetched) {
+        const err = new Error(fetched.exception.message)
+        this._onError(err)
+        return false
+      }
+      resource = fetched.stream
     }
 
     this._cleanupCurrentAudioStream(cleanupReason)
 
-    const resource = fetched.stream
     if (this.volumePercent !== 100) {
       resource.setVolume(this.volumePercent / 100)
     }


### PR DESCRIPTION
## Changes
Added seek support using `createSeekeableAudioResource` in `_connectAndPlayStream`, so it skips the full re-fetch/reconnect when seeking. Falls back to the old `_fetchResource` method if it fails or the source/protocol isn't supported (`local`, `deezer`, `sabr`, `hls`, `dash`)

## Why
`&t=X` timestamps were always ignored, track just started from 0 regardless of position. It's actually worse than just "seek doesn't work" though, since track-end is scheduled based on `trackLength - startPosition`, the track gets cut off early too. e.g. seek to 1:43 on a 2:34 track and it'll stop around 0:51 of real playback, since the audio was actually playing from 0:00 the whole time.

## Checkmarks
- [x] The modified endpoints have been tested
- [x] Used the same indentation as the rest of the project
- [x] Still compatible with LavaLink clients

## Additional information
tsc + biome pass