### PR TITLE
fix: register routeplanner sub-routes correctly

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -125,7 +125,11 @@ async function loadRoutes(): Promise<ApiRouteCollection> {
           methods: module.methods ?? defaultMethods
         }
 
-        if (pathname instanceof RegExp) {
+        if (module.paths && module.paths.length > 0) {
+          for (const explicitPath of module.paths) {
+            staticRoutes.set(explicitPath, routeData)
+          }
+        } else if (pathname instanceof RegExp) {
           dynamicRoutes.push([pathname, routeData])
         } else {
           staticRoutes.set(pathname, routeData)

--- a/src/api/routeplanner.ts
+++ b/src/api/routeplanner.ts
@@ -407,7 +407,12 @@ function handler(
  */
 const routePlannerRoute: ApiRouteModule = {
   handler,
-  methods: ['GET', 'POST']
+  methods: ['GET', 'POST'],
+  paths: [
+    '/v4/routeplanner/status',
+    '/v4/routeplanner/free/address',
+    '/v4/routeplanner/free/all'
+  ]
 }
 
 export default routePlannerRoute

--- a/src/typings/api/api.types.ts
+++ b/src/typings/api/api.types.ts
@@ -197,6 +197,11 @@ export interface ApiRouteModule {
   handler: ApiRouteHandler
 
   /**
+   * Static pathnames this module handles, overriding the filename-derived pathname.
+   */
+  paths?: string[]
+
+  /**
    * Allowed HTTP methods (defaults to GET).
    */
   methods?: ApiHttpMethod[]


### PR DESCRIPTION
## Changes
added optional `paths` field to ApiRouteModule so a module can register explicit static routes instead of relying on the filename

## Why
routeplanner.ts has no dot in the filename, so it registered as a single static route at /v4/routeplanner instead of the actual paths the handler dispatches on. every call 404s before the handler runs

## Checkmarks
- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information
tsc passes