### PR TITLE
fix: forward transition field in 12 AnimatableFilter subclasses

### DIFF
--- a/src/playback/filters/chorus.ts
+++ b/src/playback/filters/chorus.ts
@@ -75,7 +75,8 @@ export default class Chorus extends AnimatableFilter {
     super.applyAnimatedUpdate(
       {
         chorus: {
-          alpha: targetAlpha
+          alpha: targetAlpha,
+          transition: c.transition
         }
       },
       'chorus',

--- a/src/playback/filters/compressor.ts
+++ b/src/playback/filters/compressor.ts
@@ -45,7 +45,8 @@ export default class Compressor extends AnimatableFilter {
     super.applyAnimatedUpdate(
       {
         compressor: {
-          alpha: targetAlpha
+          alpha: targetAlpha,
+          transition: comp.transition
         }
       },
       'compressor',

--- a/src/playback/filters/distortion.ts
+++ b/src/playback/filters/distortion.ts
@@ -55,7 +55,8 @@ export default class Distortion extends AnimatableFilter {
     super.applyAnimatedUpdate(
       {
         distortion: {
-          alpha: targetAlpha
+          alpha: targetAlpha,
+          transition: dist.transition
         }
       },
       'distortion',

--- a/src/playback/filters/echo.ts
+++ b/src/playback/filters/echo.ts
@@ -58,7 +58,8 @@ export default class Echo extends AnimatableFilter {
     super.applyAnimatedUpdate(
       {
         echo: {
-          alpha: targetAlpha
+          alpha: targetAlpha,
+          transition: e.transition
         }
       },
       'echo',

--- a/src/playback/filters/highpass.ts
+++ b/src/playback/filters/highpass.ts
@@ -37,7 +37,8 @@ export default class Highpass extends AnimatableFilter {
     super.applyAnimatedUpdate(
       {
         highpass: {
-          targetAlpha: targetAlpha
+          targetAlpha: targetAlpha,
+          transition: rawConfig.transition
         }
       },
       'highpass',

--- a/src/playback/filters/karaoke.ts
+++ b/src/playback/filters/karaoke.ts
@@ -159,7 +159,8 @@ export default class Karaoke extends AnimatableFilter {
     super.applyAnimatedUpdate(
       {
         karaoke: {
-          alpha: targetAlpha
+          alpha: targetAlpha,
+          transition: k.transition
         }
       },
       'karaoke',

--- a/src/playback/filters/lowpass.ts
+++ b/src/playback/filters/lowpass.ts
@@ -34,7 +34,8 @@ export default class Lowpass extends AnimatableFilter {
     super.applyAnimatedUpdate(
       {
         lowpass: {
-          logSmoothing: targetLogSmoothing
+          logSmoothing: targetLogSmoothing,
+          transition: rawConfig.transition
         }
       },
       'lowpass',

--- a/src/playback/filters/phaser.ts
+++ b/src/playback/filters/phaser.ts
@@ -68,7 +68,8 @@ export default class Phaser extends AnimatableFilter {
     super.applyAnimatedUpdate(
       {
         phaser: {
-          alpha: targetAlpha
+          alpha: targetAlpha,
+          transition: p.transition
         }
       },
       'phaser',

--- a/src/playback/filters/rotation.ts
+++ b/src/playback/filters/rotation.ts
@@ -40,7 +40,8 @@ export default class Rotation extends AnimatableFilter {
     super.applyAnimatedUpdate(
       {
         rotation: {
-          alpha: targetAlpha
+          alpha: targetAlpha,
+          transition: r.transition
         }
       },
       'rotation',

--- a/src/playback/filters/spatial.ts
+++ b/src/playback/filters/spatial.ts
@@ -49,7 +49,8 @@ export default class Spatial extends AnimatableFilter {
     super.applyAnimatedUpdate(
       {
         spatial: {
-          alpha: targetAlpha
+          alpha: targetAlpha,
+          transition: s.transition
         }
       },
       'spatial',

--- a/src/playback/filters/tremolo.ts
+++ b/src/playback/filters/tremolo.ts
@@ -47,7 +47,8 @@ export default class Tremolo extends AnimatableFilter {
     super.applyAnimatedUpdate(
       {
         tremolo: {
-          alpha: targetAlpha
+          alpha: targetAlpha,
+          transition: t.transition
         }
       },
       'tremolo',

--- a/src/playback/filters/vibrato.ts
+++ b/src/playback/filters/vibrato.ts
@@ -54,7 +54,8 @@ export default class Vibrato extends AnimatableFilter {
     super.applyAnimatedUpdate(
       {
         vibrato: {
-          alpha: targetAlpha
+          alpha: targetAlpha,
+          transition: v.transition
         }
       },
       'vibrato',


### PR DESCRIPTION
## Changes
added `transition` back into the settings object passed to `applyAnimatedUpdate()` in karaoke, tremolo, vibrato, rotation, distortion, echo, chorus, compressor, lowpass, highpass, phaser, spatial

## Why
these 12 filters rebuild a fresh object before calling `applyAnimatedUpdate()` and dropped `transition` in the process, so filter changes always applied instantly regardless of what the client sent. only equalizer, timescale, channelMix forward it correctly today

## Checkmarks
- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information
tsc passes