### PR TITLE
fix: apply skipMarginMs in updateSponsorBlock

### DIFF
--- a/src/playback/player.ts
+++ b/src/playback/player.ts
@@ -3653,6 +3653,8 @@ export class Player {
       this.sponsorBlock.categories = updates.categories
     if (updates.actionTypes !== undefined)
       this.sponsorBlock.actionTypes = updates.actionTypes
+    if (updates.skipMarginMs !== undefined)
+      this.sponsorBlock.skipMarginMs = updates.skipMarginMs
   }
 
   /**


### PR DESCRIPTION
## Changes
assign `skipMarginMs` in `updateSponsorBlock()` when present, same pattern as the other 3 fields

## Why
type + PATCH handler already forwarded `skipMarginMs`, method just never wrote it, silently dropped

## Checkmarks
- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information
tsc passes