### PR TITLE
fix: recompute trackEnd fade delay for playback speed changes

### DIFF
--- a/src/playback/player.ts
+++ b/src/playback/player.ts
@@ -3175,6 +3175,7 @@ export class Player {
     if (this.connection?.audioStream) {
       this._snapshotPosition()
       this.connection.audioStream.setFilters(this.filters)
+      this._fading('trackEndSchedule', { startPosition: this._realPosition() })
     }
     if (!this.nextResourceIsCrossfade) {
       this.nextResource?.setFilters(this.filters)
@@ -3944,7 +3945,12 @@ export class Player {
       if (!Number.isFinite(total) || total <= 0) return false
 
       const startPosition = payload.startPosition || 0
-      const remaining = Math.max(0, total - startPosition)
+      const playbackSpeed =
+        this._getAudioStream()?.getEffectiveRate?.() ??
+        this._getTimescaleSpeed()
+      const remaining =
+        Math.max(0, total - startPosition) /
+        (playbackSpeed > 0 ? playbackSpeed : 1)
       const teSection = this.fading?.trackEnd as FadingSection | undefined
       const hasFade =
         teSection &&


### PR DESCRIPTION
## Changes
`trackEndSchedule` now divides `remaining` by the effective playback rate instead of using raw track-ms as the `setTimeout` delay. also reschedules it after `setFilters()` so speed changes mid-track update the pending timer

## Why
crossfade already divides by `getEffectiveRate()`, but trackEndSchedule didn't, so fades/stops fired at the wrong time whenever speed != 1x. reproduced with `timescale: { speed: 0.75 }`: fired 1min early on a 3min track

## Checkmarks
- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information
tsc passes