### PR TITLE
fix: preserve explicit null endTime through seek pipeline

### DIFF
--- a/src/api/sessions.id.groups.ts
+++ b/src/api/sessions.id.groups.ts
@@ -105,7 +105,7 @@ interface GroupsRoutePlayerManager {
   seek: (
     guildId: string,
     position?: number,
-    endTime?: number
+    endTime?: number | null
   ) => Promise<boolean | object>
   volume: (guildId: string, level: number) => Promise<boolean | object>
   setFilters: (
@@ -544,7 +544,7 @@ async function applyGroupPatch(
         await session.players.seek(
           guildId,
           playerState.state.position,
-          payload.endTime ?? undefined
+          payload.endTime
         )
       }
 

--- a/src/api/sessions.id.players.ts
+++ b/src/api/sessions.id.players.ts
@@ -434,7 +434,7 @@ interface PlayersRoutePlayerManager {
   seek: (
     guildId: string,
     position?: number,
-    endTime?: number
+    endTime?: number | null
   ) => Promise<boolean | object>
 
   /**
@@ -1322,7 +1322,7 @@ async function applyPlayerPatch(
     await session.players.seek(
       guildId,
       playerState.state.position,
-      payload.endTime ?? undefined
+      payload.endTime
     )
   }
 

--- a/src/managers/playerManager.ts
+++ b/src/managers/playerManager.ts
@@ -687,7 +687,7 @@ export default class PlayerManager {
   async seek(
     guildId: string,
     position?: number,
-    endTime?: number
+    endTime?: number | null
   ): Promise<boolean | PlayerCommandResponse> {
     const interception = await this._runInterceptors(
       'seek',

--- a/src/playback/player.ts
+++ b/src/playback/player.ts
@@ -2137,7 +2137,7 @@ export class Player {
    */
   public async seek(
     position?: number,
-    endTime?: number,
+    endTime?: number | null,
     forceLegacy = false
   ): Promise<boolean> {
     logger(
@@ -2240,12 +2240,12 @@ export class Player {
       if (forceLegacy) {
         seekPromise = this._legacySeek(
           seekPosition,
-          endTime !== undefined ? endTime : this.track.endTime
+          endTime === null ? undefined : (endTime ?? this.track.endTime)
         )
       } else if (canNativeSeek) {
         seekPromise = this._seekUsingSource(
           seekPosition,
-          endTime !== undefined ? endTime : this.track.endTime
+          endTime === null ? undefined : (endTime ?? this.track.endTime)
         )
       } else if (
         !unsupportedSources.includes(resolvedSourceName) &&
@@ -2255,12 +2255,12 @@ export class Player {
       ) {
         seekPromise = this._seekeableSeek(
           seekPosition,
-          endTime !== undefined ? endTime : this.track.endTime
+          endTime === null ? undefined : (endTime ?? this.track.endTime)
         )
       } else {
         seekPromise = this._legacySeek(
           seekPosition,
-          endTime !== undefined ? endTime : this.track.endTime
+          endTime === null ? undefined : (endTime ?? this.track.endTime)
         )
       }
 


### PR DESCRIPTION
## Changes
`seek()` now accepts `endTime: number | null` instead of just `number` across `playerManager.ts`, `player.ts` and both PATCH handlers (`sessions.id.groups.ts`, `sessions.id.players.ts`). also stopped collapsing `payload.endTime` through `?? undefined` before it reaches `seek()`

## Why 
`payload.endTime ?? undefined` turned an explicit `endTime: null` into `undefined` before it reached `seek()`, so `endTime !== undefined ? endTime : this.track.endTime` couldn't tell "clear the end time" apart from "field omitted", silently keeping the old end time instead of clearing it

## Checkmarks
- [x] The modified endpoints have been tested.
- [x] Used the same indentation as the rest of the project.
- [x] Still compatible with LavaLink clients.

## Additional information
tsc passes. fun fact: lavalink has the same issue, lines [here](https://github.com/lavalink-devs/Lavalink/blob/b7318d1e12e0330f97a737f43c9945ac926f7bb1/LavalinkServer/src/main/java/lavalink/server/player/PlayerRestHandler.kt#L174-L178)